### PR TITLE
Create HealthKitOnFHIR API

### DIFF
--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
@@ -7,10 +7,11 @@
 //
 
 import HealthKit
+import ModelsR4
 
 
-struct HealthKitOnFHIR {
-    var healthKitOnFHIR: String {
-        "HealthKitOnFHIR"
+extension HKCumulativeQuantitySample {
+    func buildCumulativeQuantitySampleObservation(_ observation: inout Observation) throws {
+        throw HealthKitOnFHIRError.notSupported
     }
 }

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
@@ -1,0 +1,17 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+import ModelsR4
+
+
+extension HKDiscreteQuantitySample {
+    func buildDiscreteQuantitySampleObservation(_ observation: inout Observation) throws {
+        throw HealthKitOnFHIRError.notSupported
+    }
+}

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKQuantitySample+Observation.swift
@@ -1,0 +1,24 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+import ModelsR4
+
+
+extension HKQuantitySample {
+    func buildQuantitySampleObservation(_ observation: inout Observation) throws {
+        switch self {
+        case let cumulativeQuantitySample as HKCumulativeQuantitySample:
+            try cumulativeQuantitySample.buildCumulativeQuantitySampleObservation(&observation)
+        case let discreteQuantitySample as HKDiscreteQuantitySample:
+            try discreteQuantitySample.buildDiscreteQuantitySampleObservation(&observation)
+        default:
+            throw HealthKitOnFHIRError.notSupported
+        }
+    }
+}

--- a/Sources/HealthKitOnFHIR/HKSample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKSample+Observation.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_exported import HealthKit
+@_exported import ModelsR4
+
+
+extension HKSample {
+    /// A FHRI observation based on the concrete subclass of `HKSample`.
+    ///
+    /// If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
+    public var observation: Observation {
+        get throws {
+            var observation = Observation(code: CodeableConcept(), status: FHIRPrimitive<ObservationStatus>(.final))
+            
+            switch self {
+            case let quantitySample as HKQuantitySample:
+                try quantitySample.buildQuantitySampleObservation(&observation)
+            default:
+                throw HealthKitOnFHIRError.notSupported
+            }
+            
+            return observation
+        }
+    }
+}

--- a/Sources/HealthKitOnFHIR/HealthKitOnFHIRError.swift
+++ b/Sources/HealthKitOnFHIR/HealthKitOnFHIRError.swift
@@ -1,0 +1,14 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+/// Error thrown by the HealthKitOnFHIR module if transforming a specific `HKSample` type to a FHIR `Observation` was not possible.
+enum HealthKitOnFHIRError: Error {
+    /// Indicates that a specific `HKSample` type is currently not supported by HealthKitOnFHIR.
+    case notSupported
+}

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -11,8 +11,39 @@ import XCTest
 
 
 final class HealthKitOnFHIRTests: XCTestCase {
-    func testHealthKitOnFHIR() throws {
-        let healthKitOnFHIR = HealthKitOnFHIR()
-        XCTAssertEqual(healthKitOnFHIR.healthKitOnFHIR, "HealthKitOnFHIR")
+    private var startDate: Date {
+        get throws {
+            let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 0) // Date Stanford University opened (https://www.stanford.edu/about/history/)
+            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+        }
+    }
+    
+    private var endDate: Date {
+        get throws {
+            let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 42)
+            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+        }
+    }
+    
+    func testCumulativeQuantitySample() throws {
+        let cumulativeQuantitySample = HKCumulativeQuantitySample(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: try startDate,
+            end: try endDate
+        )
+        XCTAssertThrowsError(try cumulativeQuantitySample.observation)
+    }
+    
+    
+    func testdiscreteQuantitySample() throws {
+        let unit = HKUnit.count().unitDivided(by: .minute())
+        let discreteQuantitySample = HKDiscreteQuantitySample(
+            type: HKQuantityType(.heartRate),
+            quantity: HKQuantity(unit: unit, doubleValue: 84),
+            start: try startDate,
+            end: try endDate
+        )
+        XCTAssertThrowsError(try discreteQuantitySample.observation)
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -36,34 +36,6 @@
             BlueprintName = "HealthKitOnFHIR"
             ReferencedContainer = "container:../..">
          </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "LocalStorage"
-            BuildableName = "LocalStorage"
-            BlueprintName = "LocalStorage"
-            ReferencedContainer = "container:../..">
-         </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "SecureStorage"
-            BuildableName = "SecureStorage"
-            BlueprintName = "SecureStorage"
-            ReferencedContainer = "container:../..">
-         </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "XCTRuntimeAssertions"
-            BuildableName = "XCTRuntimeAssertions"
-            BlueprintName = "XCTRuntimeAssertions"
-            ReferencedContainer = "container:../..">
-         </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "HealthKitDataSource"
-            BuildableName = "HealthKitDataSource"
-            BlueprintName = "HealthKitDataSource"
-            ReferencedContainer = "container:../..">
-         </BuildableReference>
       </CodeCoverageTargets>
       <Testables>
          <TestableReference


### PR DESCRIPTION
# Create HealthKitOnFHIR API

## :recycle: Current situation & Problem
This PR creates a first draft of the HealthKitOnFHIR API surface. Developers can transform any `HKSample` to a FHIR `Observation` using the `observation` computed property that can throw an `HealthKitOnFHIRError` of the conversion fails:
```swift
let cumulativeQuantitySample = HKCumulativeQuantitySample(
    type: HKQuantityType(.stepCount),
    quantity: HKQuantity(unit: .count(), doubleValue: 42),
    start: startDate,
    end: endDate
)
let observation = try cumulativeQuantitySample.observation // Functionality provided by HealthKitOnFHIR
```

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

