### PR TITLE
Convert HKQuantityTypeIdentifierStepCount to FHIR Observation

### DIFF
--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
@@ -12,6 +12,46 @@ import ModelsR4
 
 extension HKCumulativeQuantitySample {
     func buildCumulativeQuantitySampleObservation(_ observation: inout Observation) throws {
-        throw HealthKitOnFHIRError.notSupported
+        switch self.sampleType {
+        case HKQuantityType(.stepCount):
+            // Convert data to FHIR types
+            let id = Identifier(id: FHIRPrimitive(FHIRString(UUID().uuidString)))
+            let unit = "steps"
+            let value = self.quantity.doubleValue(for: HKUnit.count())
+            let periodStart = FHIRPrimitive(try DateTime(date: self.startDate))
+            let periodEnd = FHIRPrimitive(try DateTime(date: self.endDate))
+
+            // Set observation category (maps HK type to a category code (using SNOMED CT
+            // since Observation.coding does not cover activity))
+            let categoryCode = "68130003"
+            guard let categorySystem = URL(string: "http://snomed.info/sct") else { return }
+            let categoryDisplay = "Physical activity (observable entity)"
+            let categoryCoding = Coding(code: categoryCode.asFHIRStringPrimitive(),
+                                        display: categoryDisplay.asFHIRStringPrimitive(),
+                                        system: categorySystem.asFHIRURIPrimitive()
+            )
+            let category = CodeableConcept(coding: [categoryCoding])
+
+            // Create observation code (maps HK type to a LOINC code)
+            let loincCode = "55423-8"
+            guard let loincSystem = URL(string: "http://loinc.org") else { return }
+            let loincDisplay = "Number of steps in unspecified time Pedometer"
+            let loincCoding = Coding(code: loincCode.asFHIRStringPrimitive(),
+                                     display: loincDisplay.asFHIRStringPrimitive(),
+                                     system: loincSystem.asFHIRURIPrimitive()
+            )
+
+            // Build observation
+            observation.identifier = [id]
+            observation.category = [category]
+            observation.code.coding = [loincCoding]
+            observation.effective = .period(Period(end: periodEnd, start: periodStart))
+            observation.issued = FHIRPrimitive(try Instant(date: Date()))
+            observation.value = .quantity(Quantity(unit: unit.asFHIRStringPrimitive(),
+                                                   value: value.asFHIRDecimalPrimitive())
+            )
+        default:
+            throw HealthKitOnFHIRError.notSupported
+        }
     }
 }

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
@@ -24,21 +24,27 @@ extension HKCumulativeQuantitySample {
             // Set observation category (maps HK type to a category code (using SNOMED CT
             // since Observation.coding does not cover activity))
             let categoryCode = "68130003"
-            guard let categorySystem = URL(string: "http://snomed.info/sct") else { return }
+            guard let categorySystem = URL(string: "http://snomed.info/sct") else {
+                return
+            }
             let categoryDisplay = "Physical activity (observable entity)"
-            let categoryCoding = Coding(code: categoryCode.asFHIRStringPrimitive(),
-                                        display: categoryDisplay.asFHIRStringPrimitive(),
-                                        system: categorySystem.asFHIRURIPrimitive()
+            let categoryCoding = Coding(
+                code: categoryCode.asFHIRStringPrimitive(),
+                display: categoryDisplay.asFHIRStringPrimitive(),
+                system: categorySystem.asFHIRURIPrimitive()
             )
             let category = CodeableConcept(coding: [categoryCoding])
 
             // Create observation code (maps HK type to a LOINC code)
             let loincCode = "55423-8"
-            guard let loincSystem = URL(string: "http://loinc.org") else { return }
+            guard let loincSystem = URL(string: "http://loinc.org") else {
+                return
+            }
             let loincDisplay = "Number of steps in unspecified time Pedometer"
-            let loincCoding = Coding(code: loincCode.asFHIRStringPrimitive(),
-                                     display: loincDisplay.asFHIRStringPrimitive(),
-                                     system: loincSystem.asFHIRURIPrimitive()
+            let loincCoding = Coding(
+                code: loincCode.asFHIRStringPrimitive(),
+                display: loincDisplay.asFHIRStringPrimitive(),
+                system: loincSystem.asFHIRURIPrimitive()
             )
 
             // Build observation
@@ -47,8 +53,11 @@ extension HKCumulativeQuantitySample {
             observation.code.coding = [loincCoding]
             observation.effective = .period(Period(end: periodEnd, start: periodStart))
             observation.issued = FHIRPrimitive(try Instant(date: Date()))
-            observation.value = .quantity(Quantity(unit: unit.asFHIRStringPrimitive(),
-                                                   value: value.asFHIRDecimalPrimitive())
+            observation.value = .quantity(
+                Quantity(
+                    unit: unit.asFHIRStringPrimitive(),
+                    value: value.asFHIRDecimalPrimitive()
+                )
             )
         default:
             throw HealthKitOnFHIRError.notSupported

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -39,28 +39,42 @@ final class HealthKitOnFHIRTests: XCTestCase {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
         let data = try encoder.encode(observation)
-        print(String(data: data, encoding: .utf8)!)
+        if let jsonString = String(data: data, encoding: .utf8) {
+            print(jsonString)
+        }
 
         // Test mapping to LOINC code
-        guard let loincSystem = URL(string: "http://loinc.org") else { return }
-        let loincCoding = Coding(code: "55423-8".asFHIRStringPrimitive(),
-                                 display: "Number of steps in unspecified time Pedometer".asFHIRStringPrimitive(),
-                                 system: loincSystem.asFHIRURIPrimitive()
+        guard let loincSystem = URL(string: "http://loinc.org") else {
+            return
+        }
+        let loincCoding = Coding(
+            code: "55423-8".asFHIRStringPrimitive(),
+            display: "Number of steps in unspecified time Pedometer".asFHIRStringPrimitive(),
+            system: loincSystem.asFHIRURIPrimitive()
         )
         XCTAssertEqual(observation.code.coding, [loincCoding])
 
         // Test mapping to category
-        guard let snomedSystem = URL(string: "http://snomed.info/sct") else { return }
-        let categoryCoding = Coding(code: "68130003".asFHIRStringPrimitive(),
-                                    display: "Physical activity (observable entity)".asFHIRStringPrimitive(),
-                                    system: snomedSystem.asFHIRURIPrimitive()
+        guard let snomedSystem = URL(string: "http://snomed.info/sct") else {
+            return
+        }
+        let categoryCoding = Coding(
+            code: "68130003".asFHIRStringPrimitive(),
+            display: "Physical activity (observable entity)".asFHIRStringPrimitive(),
+            system: snomedSystem.asFHIRURIPrimitive()
         )
         let category = CodeableConcept(coding: [categoryCoding])
         XCTAssertEqual(observation.category, [category])
 
         // Test value
-        XCTAssertEqual(observation.value,
-            .quantity(Quantity(unit: "steps".asFHIRStringPrimitive(), value: 42.asFHIRDecimalPrimitive()))
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    unit: "steps".asFHIRStringPrimitive(),
+                    value: 42.asFHIRDecimalPrimitive()
+                )
+            )
         )
     }
     

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -32,7 +32,36 @@ final class HealthKitOnFHIRTests: XCTestCase {
             start: try startDate,
             end: try endDate
         )
-        XCTAssertThrowsError(try cumulativeQuantitySample.observation)
+
+        let observation = try cumulativeQuantitySample.observation
+
+        // Print out the FHIR Observation JSON
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try encoder.encode(observation)
+        print(String(data: data, encoding: .utf8)!)
+
+        // Test mapping to LOINC code
+        guard let loincSystem = URL(string: "http://loinc.org") else { return }
+        let loincCoding = Coding(code: "55423-8".asFHIRStringPrimitive(),
+                                 display: "Number of steps in unspecified time Pedometer".asFHIRStringPrimitive(),
+                                 system: loincSystem.asFHIRURIPrimitive()
+        )
+        XCTAssertEqual(observation.code.coding, [loincCoding])
+
+        // Test mapping to category
+        guard let snomedSystem = URL(string: "http://snomed.info/sct") else { return }
+        let categoryCoding = Coding(code: "68130003".asFHIRStringPrimitive(),
+                                    display: "Physical activity (observable entity)".asFHIRStringPrimitive(),
+                                    system: snomedSystem.asFHIRURIPrimitive()
+        )
+        let category = CodeableConcept(coding: [categoryCoding])
+        XCTAssertEqual(observation.category, [category])
+
+        // Test value
+        XCTAssertEqual(observation.value,
+            .quantity(Quantity(unit: "steps".asFHIRStringPrimitive(), value: 42.asFHIRDecimalPrimitive()))
+        )
     }
     
     


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Convert HKQuantityTypeIdentifierStepCount to FHIR Observation

## :bulb: Proposed solution
In this PR, we add and test the first conversion from an HKQuantityType to a FHIR observation, including mapping to a LOINC code and category code.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

