### PR TITLE
Create HKQuantityType to Code System Mapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,9 @@ let package = Package(
             name: "HealthKitOnFHIR",
             dependencies: [
                 .product(name: "ModelsR4", package: "FHIRModels")
+            ],
+            resources: [
+                .process("mapping.json")
             ]
         ),
         .testTarget(

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
@@ -12,45 +12,15 @@ import ModelsR4
 
 extension HKCumulativeQuantitySample {
     func buildCumulativeQuantitySampleObservation(_ builder: inout ObservationBuilder) throws {
-        builder
-            .addIdentifiers([Identifier(id: self.uuid.uuidString.asFHIRStringPrimitive())])
-            .setIssued(on: Date())
-            .setEffective(startDate: self.startDate, endDate: self.endDate)
+        builder.setEffective(startDate: self.startDate, endDate: self.endDate)
 
         switch self.sampleType {
         case HKQuantityType(.stepCount):
-            // Convert data to FHIR types
             let unit = "steps"
             let value = self.quantity.doubleValue(for: HKUnit.count())
 
-            // Set observation category
-            let categoryCode = "68130003"
-            guard let categorySystem = URL(string: "http://snomed.info/sct") else {
-                return
-            }
-            let categoryDisplay = "Physical activity (observable entity)"
-            let categoryCoding = Coding(
-                code: categoryCode.asFHIRStringPrimitive(),
-                display: categoryDisplay.asFHIRStringPrimitive(),
-                system: categorySystem.asFHIRURIPrimitive()
-            )
-            let category = CodeableConcept(coding: [categoryCoding])
-
-            // Set observation code
-            let loincCode = "55423-8"
-            guard let loincSystem = URL(string: "http://loinc.org") else {
-                return
-            }
-            let loincDisplay = "Number of steps in unspecified time Pedometer"
-            let loincCoding = Coding(
-                code: loincCode.asFHIRStringPrimitive(),
-                display: loincDisplay.asFHIRStringPrimitive(),
-                system: loincSystem.asFHIRURIPrimitive()
-            )
-
             builder
-                .addCategories([category])
-                .addCodings([loincCoding])
+                .addCodings(self.sampleType.convertToCodes())
                 .setValue(
                     Quantity(
                         unit: unit.asFHIRStringPrimitive(),

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKQuantitySample+Observation.swift
@@ -12,6 +12,10 @@ import ModelsR4
 
 extension HKQuantitySample {
     func buildQuantitySampleObservation(_ builder: inout ObservationBuilder) throws {
+        builder
+            .addIdentifiers([Identifier(id: self.uuid.uuidString.asFHIRStringPrimitive())])
+            .setIssued(on: Date())
+        
         switch self {
         case let cumulativeQuantitySample as HKCumulativeQuantitySample:
             try cumulativeQuantitySample.buildCumulativeQuantitySampleObservation(&builder)

--- a/Sources/HealthKitOnFHIR/HKTypeCodeSystemMapper.swift
+++ b/Sources/HealthKitOnFHIR/HKTypeCodeSystemMapper.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKit
+import ModelsR4
+
+extension HKSampleType {
+    struct HKTypeCodeMapping: Codable {
+        let hktype: String
+        let codes: [MappedCode]
+
+        static let allMappings: [HKTypeCodeMapping] = Bundle.module.decode(file: "mapping.json")
+    }
+
+    struct MappedCode: Codable {
+        let code, display: String
+        let system: String
+    }
+
+    func convertToCodes() -> [Coding] {
+        guard let mapping = HKTypeCodeMapping.allMappings.first(where: { $0.hktype == self.identifier }) else {
+            return []
+        }
+        let mappedCodes = mapping.codes
+
+        var allCodes = [Coding]()
+        for mappedCode in mappedCodes {
+            guard let mappedSystem = URL(string: mappedCode.system) else {
+                continue
+            }
+
+            allCodes.append(
+                Coding(
+                    code: mappedCode.code.asFHIRStringPrimitive(),
+                    display: mappedCode.display.asFHIRStringPrimitive(),
+                    system: FHIRPrimitive(FHIRURI(mappedSystem))
+                )
+            )
+        }
+        return allCodes
+    }
+}
+
+extension Foundation.Bundle {
+    func decode<T: Decodable>(file: String) -> T {
+        guard let url = self.url(forResource: file, withExtension: nil) else {
+            fatalError("Could not find \(file) in the module.")
+        }
+
+        guard let data = try? Data(contentsOf: url) else {
+            fatalError("Could not load \(file) in the module.")
+        }
+
+        let decoder = JSONDecoder()
+        guard let loadedData = try? decoder.decode(T.self, from: data) else {
+            fatalError("Could not decode \(file) in the module.")
+        }
+
+        return loadedData
+    }
+}

--- a/Sources/HealthKitOnFHIR/mapping.json
+++ b/Sources/HealthKitOnFHIR/mapping.json
@@ -1,0 +1,12 @@
+[
+    {
+        "hktype": "HKQuantityTypeIdentifierStepCount",
+        "codes": [
+            {
+                "code": "55423-8",
+                "display": "Number of steps in unspecified time Pedometer",
+                "system": "http://loinc.org"
+            }
+        ]
+    }
+]

--- a/Sources/HealthKitOnFHIR/mapping.json.license
+++ b/Sources/HealthKitOnFHIR/mapping.json.license
@@ -1,0 +1,5 @@
+This source file is part of the ResearchKitOnFHIR open source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -43,7 +43,6 @@ final class HealthKitOnFHIRTests: XCTestCase {
             print(jsonString)
         }
 
-        // Test mapping to LOINC code
         guard let loincSystem = URL(string: "http://loinc.org") else {
             return
         }
@@ -54,19 +53,6 @@ final class HealthKitOnFHIRTests: XCTestCase {
         )
         XCTAssertEqual(observation.code.coding, [loincCoding])
 
-        // Test mapping to category
-        guard let snomedSystem = URL(string: "http://snomed.info/sct") else {
-            return
-        }
-        let categoryCoding = Coding(
-            code: "68130003".asFHIRStringPrimitive(),
-            display: "Physical activity (observable entity)".asFHIRStringPrimitive(),
-            system: snomedSystem.asFHIRURIPrimitive()
-        )
-        let category = CodeableConcept(coding: [categoryCoding])
-        XCTAssertEqual(observation.category, [category])
-
-        // Test value
         XCTAssertEqual(
             observation.value,
             .quantity(


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Create HKQuantityType to Code System Mapper

## :bulb: Proposed solution
Creates an extension that maps between HKQuantityTypes and corresponding codes in standardized Code Systems (e.g. LOINC, SNOMED CT). Mappings are configured via `mapping.json`.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

