### PR TITLE
Adds conversion for Oxygen Saturation

### DIFF
--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
@@ -12,23 +12,25 @@ import ModelsR4
 
 extension HKCumulativeQuantitySample {
     func buildCumulativeQuantitySampleObservation(_ builder: inout ObservationBuilder) throws {
-        builder.setEffective(startDate: self.startDate, endDate: self.endDate)
+        var unit: String?
+        var value: Double?
 
         switch self.quantityType {
         case HKQuantityType(.stepCount):
-            let unit = "steps"
-            let value = self.quantity.doubleValue(for: HKUnit.count())
-
-            builder
-                .addCodings(self.sampleType.convertToCodes())
-                .setValue(
-                    Quantity(
-                        unit: unit.asFHIRStringPrimitive(),
-                        value: value.asFHIRDecimalPrimitive()
-                    )
-                )
+            unit = "steps"
+            value = self.quantity.doubleValue(for: HKUnit.count())
         default:
             throw HealthKitOnFHIRError.notSupported
         }
+
+        builder
+            .setEffective(startDate: self.startDate, endDate: self.endDate)
+            .addCodings(self.sampleType.convertToCodes())
+            .setValue(
+                Quantity(
+                    unit: unit?.asFHIRStringPrimitive(),
+                    value: value?.asFHIRDecimalPrimitive()
+                )
+            )
     }
 }

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
@@ -12,35 +12,31 @@ import ModelsR4
 
 extension HKDiscreteQuantitySample {
     func buildDiscreteQuantitySampleObservation(_ builder: inout ObservationBuilder) throws {
-        builder.setEffective(startDate: self.startDate, endDate: self.endDate)
+        var unit = ""
+        var value = 0.0
 
         switch self.quantityType {
         case HKQuantityType(.heartRate):
-            let unit = "count/min"
-            let value = self.quantity.doubleValue(for: HKUnit(from: unit))
-
-            builder
-                .addCodings(self.sampleType.convertToCodes())
-                .setValue(
-                    Quantity(
-                        unit: unit.asFHIRStringPrimitive(),
-                        value: value.asFHIRDecimalPrimitive()
-                    )
-                )
+            unit = "count/min"
+            value = self.quantity.doubleValue(for: HKUnit(from: unit))
         case HKQuantityType(.bloodGlucose):
-            let unit = "mg/dL"
-            let value = self.quantity.doubleValue(for: HKUnit(from: unit))
-
-            builder
-                .addCodings(self.sampleType.convertToCodes())
-                .setValue(
-                    Quantity(
-                        unit: unit.asFHIRStringPrimitive(),
-                        value: value.asFHIRDecimalPrimitive()
-                    )
-                )
+            unit = "mg/dL"
+            value = self.quantity.doubleValue(for: HKUnit(from: unit))
+        case HKQuantityType(.oxygenSaturation):
+            unit = "%"
+            value = self.quantity.doubleValue(for: HKUnit.percent())
         default:
             throw HealthKitOnFHIRError.notSupported
         }
+
+        builder
+            .setEffective(startDate: self.startDate, endDate: self.endDate)
+            .addCodings(self.sampleType.convertToCodes())
+            .setValue(
+                Quantity(
+                    unit: unit.asFHIRStringPrimitive(),
+                    value: value.asFHIRDecimalPrimitive()
+                )
+            )
     }
 }

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
@@ -12,16 +12,16 @@ import ModelsR4
 
 extension HKDiscreteQuantitySample {
     func buildDiscreteQuantitySampleObservation(_ builder: inout ObservationBuilder) throws {
-        var unit = ""
-        var value = 0.0
+        var unit: String?
+        var value: Double?
 
         switch self.quantityType {
         case HKQuantityType(.heartRate):
             unit = "count/min"
-            value = self.quantity.doubleValue(for: HKUnit(from: unit))
+            value = self.quantity.doubleValue(for: HKUnit(from: "count/min"))
         case HKQuantityType(.bloodGlucose):
             unit = "mg/dL"
-            value = self.quantity.doubleValue(for: HKUnit(from: unit))
+            value = self.quantity.doubleValue(for: HKUnit(from: "mg/dL"))
         case HKQuantityType(.oxygenSaturation):
             unit = "%"
             value = self.quantity.doubleValue(for: HKUnit.percent())
@@ -34,8 +34,8 @@ extension HKDiscreteQuantitySample {
             .addCodings(self.sampleType.convertToCodes())
             .setValue(
                 Quantity(
-                    unit: unit.asFHIRStringPrimitive(),
-                    value: value.asFHIRDecimalPrimitive()
+                    unit: unit?.asFHIRStringPrimitive(),
+                    value: value?.asFHIRDecimalPrimitive()
                 )
             )
     }

--- a/Sources/HealthKitOnFHIR/mapping.json
+++ b/Sources/HealthKitOnFHIR/mapping.json
@@ -28,5 +28,15 @@
                 "system": "http://loinc.org"
             }
         ]
+    },
+    {
+        "hktype": "HKQuantityTypeIdentifierOxygenSaturation",
+        "codes": [
+            {
+                "code": "59408-5",
+                "display": "Oxygen saturation in Arterial blood by Pulse oximetry",
+                "system": "http://loinc.org"
+            }
+        ]
     }
 ]

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -122,4 +122,16 @@ final class HealthKitOnFHIRTests: XCTestCase {
             )
         )
     }
+
+    func testUnsupportedTypeSample() throws {
+        let unit = HKUnit.gram()
+        let sampleType = HKQuantityType(.dietaryVitaminC)
+        let vitaminCSample = HKQuantitySample(
+            type: sampleType,
+            quantity: HKQuantity(unit: unit, doubleValue: 1),
+            start: try startDate,
+            end: try endDate
+        )
+        XCTAssertThrowsError(try vitaminCSample.observation)
+    }
 }

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -27,7 +27,7 @@ final class HealthKitOnFHIRTests: XCTestCase {
 
     func testBloodGlucose() throws {
         let sampleType = HKQuantityType(.bloodGlucose)
-        let bloodGlucoseSample = HKDiscreteQuantitySample(
+        let bloodGlucoseSample = HKQuantitySample(
             type: sampleType,
             quantity: HKQuantity(unit: HKUnit(from: "mg/dL"), doubleValue: 99),
             start: try startDate,
@@ -51,7 +51,7 @@ final class HealthKitOnFHIRTests: XCTestCase {
     
     func testStepCount() throws {
         let sampleType = HKQuantityType(.stepCount)
-        let stepCountSample = HKCumulativeQuantitySample(
+        let stepCountSample = HKQuantitySample(
             type: sampleType,
             quantity: HKQuantity(unit: .count(), doubleValue: 42),
             start: try startDate,
@@ -76,7 +76,7 @@ final class HealthKitOnFHIRTests: XCTestCase {
     func testHeartRateSample() throws {
         let unit = HKUnit.count().unitDivided(by: .minute())
         let sampleType = HKQuantityType(.heartRate)
-        let heartRateSample = HKDiscreteQuantitySample(
+        let heartRateSample = HKQuantitySample(
             type: sampleType,
             quantity: HKQuantity(unit: unit, doubleValue: 84),
             start: try startDate,
@@ -93,6 +93,31 @@ final class HealthKitOnFHIRTests: XCTestCase {
                 Quantity(
                     unit: "count/min".asFHIRStringPrimitive(),
                     value: 84.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testOxygenSaturationSample() throws {
+        let unit = HKUnit.percent()
+        let sampleType = HKQuantityType(.oxygenSaturation)
+        let oxygenSaturationSample = HKQuantitySample(
+            type: sampleType,
+            quantity: HKQuantity(unit: unit, doubleValue: 99),
+            start: try startDate,
+            end: try endDate
+        )
+
+        let observation = try oxygenSaturationSample.observation
+
+        XCTAssertEqual(observation.code.coding, sampleType.convertToCodes())
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    unit: "%".asFHIRStringPrimitive(),
+                    value: 99.asFHIRDecimalPrimitive()
                 )
             )
         )


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Adds conversion for Oxygen Saturation

## :bulb: Proposed solution
Adds ability to convert [HKQuantityTypeIdentifierOxygenSaturation](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifieroxygensaturation) values to FHIR observations.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

