### PR TITLE
Adds conversion for Body Temperature

### DIFF
--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKCumulativeQuantitySample/HKCumulativeQuantitySample+Observation.swift
@@ -22,7 +22,7 @@ extension HKCumulativeQuantitySample {
         default:
             throw HealthKitOnFHIRError.notSupported
         }
-
+        
         builder
             .setEffective(startDate: self.startDate, endDate: self.endDate)
             .addCodings(self.sampleType.convertToCodes())

--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
@@ -16,12 +16,15 @@ extension HKDiscreteQuantitySample {
         var value: Double?
 
         switch self.quantityType {
-        case HKQuantityType(.heartRate):
-            unit = "count/min"
-            value = self.quantity.doubleValue(for: HKUnit(from: "count/min"))
         case HKQuantityType(.bloodGlucose):
             unit = "mg/dL"
             value = self.quantity.doubleValue(for: HKUnit(from: "mg/dL"))
+        case HKQuantityType(.bodyTemperature):
+            unit = "degC"
+            value = self.quantity.doubleValue(for: HKUnit.degreeCelsius())
+        case HKQuantityType(.heartRate):
+            unit = "count/min"
+            value = self.quantity.doubleValue(for: HKUnit(from: "count/min"))
         case HKQuantityType(.oxygenSaturation):
             unit = "%"
             value = self.quantity.doubleValue(for: HKUnit.percent())

--- a/Sources/HealthKitOnFHIR/mapping.json
+++ b/Sources/HealthKitOnFHIR/mapping.json
@@ -1,10 +1,20 @@
 [
     {
-        "hktype": "HKQuantityTypeIdentifierStepCount",
+        "hktype": "HKQuantityTypeIdentifierBloodGlucose",
         "codes": [
             {
-                "code": "55423-8",
-                "display": "Number of steps in unspecified time Pedometer",
+                "code": "41653-7",
+                "display": "Glucose Glucometer (BldC) [Mass/Vol]",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    {
+        "hktype": "HKQuantityTypeIdentifierBodyTemperature",
+        "codes": [
+            {
+                "code": "8310-5",
+                "display": "Body temperature",
                 "system": "http://loinc.org"
             }
         ]
@@ -20,21 +30,21 @@
         ]
     },
     {
-        "hktype": "HKQuantityTypeIdentifierBloodGlucose",
-        "codes": [
-            {
-                "code": "41653-7",
-                "display": "Glucose Glucometer (BldC) [Mass/Vol]",
-                "system": "http://loinc.org"
-            }
-        ]
-    },
-    {
         "hktype": "HKQuantityTypeIdentifierOxygenSaturation",
         "codes": [
             {
                 "code": "59408-5",
                 "display": "Oxygen saturation in Arterial blood by Pulse oximetry",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    {
+        "hktype": "HKQuantityTypeIdentifierStepCount",
+        "codes": [
+            {
+                "code": "55423-8",
+                "display": "Number of steps in unspecified time Pedometer",
                 "system": "http://loinc.org"
             }
         ]

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -123,6 +123,31 @@ final class HealthKitOnFHIRTests: XCTestCase {
         )
     }
 
+    func testBodyTemperatureSample() throws {
+        let unit = HKUnit.degreeCelsius()
+        let sampleType = HKQuantityType(.bodyTemperature)
+        let bodyTemperatureSample = HKQuantitySample(
+            type: sampleType,
+            quantity: HKQuantity(unit: unit, doubleValue: 37),
+            start: try startDate,
+            end: try startDate
+        )
+
+        let observation = try bodyTemperatureSample.observation
+
+        XCTAssertEqual(observation.code.coding, sampleType.convertToCodes())
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    unit: "degC".asFHIRStringPrimitive(),
+                    value: 37.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
     func testUnsupportedTypeSample() throws {
         let unit = HKUnit.gram()
         let sampleType = HKQuantityType(.dietaryVitaminC)


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Adds conversion for Body Temperature

## :bulb: Proposed solution
Adds support for converting [HKQuantityTypeIdentifierBodyTemperature](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierbodytemperature) data to FHIR Observations.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

