### PR TITLE
Adds conversion for Height

### DIFF
--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
@@ -25,6 +25,9 @@ extension HKDiscreteQuantitySample {
         case HKQuantityType(.heartRate):
             unit = "count/min"
             value = self.quantity.doubleValue(for: HKUnit(from: "count/min"))
+        case HKQuantityType(.height):
+            unit = "m"
+            value = self.quantity.doubleValue(for: HKUnit.meter())
         case HKQuantityType(.oxygenSaturation):
             unit = "%"
             value = self.quantity.doubleValue(for: HKUnit.percent())

--- a/Sources/HealthKitOnFHIR/mapping.json
+++ b/Sources/HealthKitOnFHIR/mapping.json
@@ -30,6 +30,16 @@
         ]
     },
     {
+        "hktype": "HKQuantityTypeIdentifierHeight",
+        "codes": [
+            {
+                "code": "8302-2",
+                "display": "Body height",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    {
         "hktype": "HKQuantityTypeIdentifierOxygenSaturation",
         "codes": [
             {

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -148,6 +148,31 @@ final class HealthKitOnFHIRTests: XCTestCase {
         )
     }
 
+    func testHeightSample() throws {
+        let unit = HKUnit.meter()
+        let sampleType = HKQuantityType(.height)
+        let heightSample = HKQuantitySample(
+            type: sampleType,
+            quantity: HKQuantity(unit: unit, doubleValue: 1.77),
+            start: try startDate,
+            end: try startDate
+        )
+
+        let observation = try heightSample.observation
+
+        XCTAssertEqual(observation.code.coding, sampleType.convertToCodes())
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    unit: "m".asFHIRStringPrimitive(),
+                    value: 1.77.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
     func testUnsupportedTypeSample() throws {
         let unit = HKUnit.gram()
         let sampleType = HKQuantityType(.dietaryVitaminC)


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Adds conversion for Height

## :bulb: Proposed solution
Adds support for converting [HKQuantityTypeIdentifierHeight](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/1615039-height) data to FHIR Observations.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

