### PR TITLE
Adds conversion for Body Mass

### DIFF
--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
@@ -19,6 +19,9 @@ extension HKDiscreteQuantitySample {
         case HKQuantityType(.bloodGlucose):
             unit = "mg/dL"
             value = self.quantity.doubleValue(for: HKUnit(from: "mg/dL"))
+        case HKQuantityType(.bodyMass):
+            unit = "kg"
+            value = self.quantity.doubleValue(for: HKUnit.gramUnit(with: .kilo))
         case HKQuantityType(.bodyTemperature):
             unit = "degC"
             value = self.quantity.doubleValue(for: HKUnit.degreeCelsius())

--- a/Sources/HealthKitOnFHIR/mapping.json
+++ b/Sources/HealthKitOnFHIR/mapping.json
@@ -10,6 +10,16 @@
         ]
     },
     {
+        "hktype": "HKQuantityTypeIdentifierBodyMass",
+        "codes": [
+            {
+                "code": "29463-7",
+                "display": "Body weight",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    {
         "hktype": "HKQuantityTypeIdentifierBodyTemperature",
         "codes": [
             {

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -173,6 +173,31 @@ final class HealthKitOnFHIRTests: XCTestCase {
         )
     }
 
+    func testBodyMassSample() throws {
+        let unit = HKUnit.gramUnit(with: .kilo)
+        let sampleType = HKQuantityType(.bodyMass)
+        let bodyMassSample = HKQuantitySample(
+            type: sampleType,
+            quantity: HKQuantity(unit: unit, doubleValue: 60),
+            start: try startDate,
+            end: try startDate
+        )
+
+        let observation = try bodyMassSample.observation
+
+        XCTAssertEqual(observation.code.coding, sampleType.convertToCodes())
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    unit: "kg".asFHIRStringPrimitive(),
+                    value: 60.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
     func testUnsupportedTypeSample() throws {
         let unit = HKUnit.gram()
         let sampleType = HKQuantityType(.dietaryVitaminC)


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Adds conversion for Body Mass

## :bulb: Proposed solution
Adds support for converting HKQuantityTypeIdentifierBodyMass data to FHIR Observations.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

