### PR TITLE
Adds conversion for Respiratory Rate

### DIFF
--- a/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKQuantitySample/HKDiscreteQuantitySample/HKDiscreteQuantitySample+Observation.swift
@@ -34,6 +34,9 @@ extension HKDiscreteQuantitySample {
         case HKQuantityType(.oxygenSaturation):
             unit = "%"
             value = self.quantity.doubleValue(for: HKUnit.percent())
+        case HKQuantityType(.respiratoryRate):
+            unit = "count/min"
+            value = self.quantity.doubleValue(for: HKUnit(from: "count/min"))
         default:
             throw HealthKitOnFHIRError.notSupported
         }

--- a/Sources/HealthKitOnFHIR/mapping.json
+++ b/Sources/HealthKitOnFHIR/mapping.json
@@ -60,6 +60,16 @@
         ]
     },
     {
+        "hktype": "HKQuantityTypeIdentifierRespiratoryRate",
+        "codes": [
+            {
+                "code": "9279-1",
+                "display": "Respiratory rate",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    {
         "hktype": "HKQuantityTypeIdentifierStepCount",
         "codes": [
             {

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -198,6 +198,31 @@ final class HealthKitOnFHIRTests: XCTestCase {
         )
     }
 
+    func testRespiratoryRateSample() throws {
+        let unit = HKUnit(from: "count/min")
+        let sampleType = HKQuantityType(.respiratoryRate)
+        let respiratoryRateSample = HKQuantitySample(
+            type: sampleType,
+            quantity: HKQuantity(unit: unit, doubleValue: 18),
+            start: try startDate,
+            end: try endDate
+        )
+
+        let observation = try respiratoryRateSample.observation
+
+        XCTAssertEqual(observation.code.coding, sampleType.convertToCodes())
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    unit: "count/min".asFHIRStringPrimitive(),
+                    value: 18.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
     func testUnsupportedTypeSample() throws {
         let unit = HKUnit.gram()
         let sampleType = HKQuantityType(.dietaryVitaminC)


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Adds conversion for Respiratory Rate

## :bulb: Proposed solution

Adds support for converting [HKQuantityTypeIdentifierRespiratoryRate](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/1615094-respiratoryrate) data to FHIR Observations.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

