### PR TITLE
Map units to standardized UCUM codes

### DIFF
--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -9,29 +9,41 @@
 public struct MappedUnit: Codable {
     private enum CodingKeys: String, CodingKey {
         case hkunit
-        case unitAlias
+        case unit
+        case system
+        case code
     }
 
     public let hkunit: String
-    public let unitAlias: String?
-
+    public let unit: String
+    public let system: URL?
+    public let code: String?
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         let hkunit = try values.decode(String.self, forKey: .hkunit)
-        let unitAlias = try values.decodeIfPresent(String.self, forKey: .unitAlias)
+        let unit = try values.decode(String.self, forKey: .unit)
+        let system = try values.decodeIfPresent(URL.self, forKey: .system)
+        let code = try values.decodeIfPresent(String.self, forKey: .code)
 
-        self.init(hkunit: hkunit, unitAlias: unitAlias)
+        self.init(hkunit: hkunit,
+                  unit: unit,
+                  system: system,
+                  code: code)
     }
 
     public init(
         hkunit: String,
-        unitAlias: String?
+        unit: String,
+        system: URL?,
+        code: String?
     ) {
         // Unfortunately this method throws an Objective-C exception when an error occurs, we can not catch this here.
         _ = HKUnit(from: hkunit)
 
         self.hkunit = hkunit
-        self.unitAlias = unitAlias
+        self.unit = unit
+        self.system = system
+        self.code = code
     }
 }

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -26,10 +26,12 @@ public struct MappedUnit: Codable {
         let system = try values.decodeIfPresent(URL.self, forKey: .system)
         let code = try values.decodeIfPresent(String.self, forKey: .code)
 
-        self.init(hkunit: hkunit,
-                  unit: unit,
-                  system: system,
-                  code: code)
+        self.init(
+            hkunit: hkunit,
+            unit: unit,
+            system: system,
+            code: code
+        )
     }
 
     public init(

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -47,7 +47,9 @@ extension HKQuantitySample {
 
     private func buildQuantity(_ mapping: HKQuantitySampleMapping) -> Quantity {
         Quantity(
-            unit: (mapping.unit.unitAlias ?? mapping.unit.hkunit).asFHIRStringPrimitive(),
+            code: mapping.unit.code?.asFHIRStringPrimitive(),
+            system: mapping.unit.system?.asFHIRURIPrimitive(),
+            unit: mapping.unit.unit.asFHIRStringPrimitive(),
             value: self.quantity.doubleValue(for: HKUnit(from: mapping.unit.hkunit)).asFHIRDecimalPrimitive()
         )
     }

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -23,7 +23,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "mg/dL"
+                "hkunit": "mg/dL",
+                "unit": "mg/dL",
+                "system": "http://unitsofmeasure.org",
+                "code": "mg/dL"
             }
         },
         "HKQuantityTypeIdentifierBodyMass": {
@@ -35,7 +38,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "kg"
+                "hkunit": "lb",
+                "unit": "lbs",
+                "system": "http://unitsofmeasure.org",
+                "code": "[lb_av]"
             }
         },
         "HKQuantityTypeIdentifierBloodPressureDiastolic": {
@@ -47,7 +53,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "mmHg"
+                "hkunit": "mmHg",
+                "unit": "mmHg",
+                "system": "http://unitsofmeasure.org",
+                "code": "mm[Hg]"
             }
         },
         "HKQuantityTypeIdentifierBloodPressureSystolic": {
@@ -59,7 +68,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "mmHg"
+                "hkunit": "mmHg",
+                "unit": "mmHg",
+                "system": "http://unitsofmeasure.org",
+                "code": "mm[Hg]"
             }
         },
         "HKQuantityTypeIdentifierBodyTemperature": {
@@ -71,7 +83,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "degC"
+                "hkunit": "degC",
+                "unit": "C",
+                "system": "http://unitsofmeasure.org",
+                "code": "Cel"
             }
         },
         "HKQuantityTypeIdentifierHeartRate": {
@@ -84,7 +99,9 @@
             ],
             "unit": {
                 "hkunit": "count/min",
-                "unitAlias": "beats/min"
+                "unit": "beats/minute",
+                "system": "http://unitsofmeasure.org",
+                "code": "/min"
             }
         },
         "HKQuantityTypeIdentifierHeight": {
@@ -96,7 +113,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "m"
+                "hkunit": "in",
+                "unit": "in",
+                "system": "http://unitsofmeasure.org",
+                "code": "[in_i]"
             }
         },
         "HKQuantityTypeIdentifierOxygenSaturation": {
@@ -108,7 +128,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "%"
+                "hkunit": "%",
+                "unit": "%",
+                "system": "http://unitsofmeasure.org",
+                "code": "%"
             }
         },
         "HKQuantityTypeIdentifierRespiratoryRate": {
@@ -120,7 +143,10 @@
                 }
             ],
             "unit": {
-                "hkunit": "count/min"
+                "hkunit": "count/min",
+                "unit": "breaths/minute",
+                "system": "http://unitsofmeasure.org",
+                "code": "/min"
             }
         },
         "HKQuantityTypeIdentifierStepCount": {
@@ -133,7 +159,7 @@
             ],
             "unit": {
                 "hkunit": "count",
-                "unitAlias": "steps"
+                "unit": "steps"
             }
         }
     }

--- a/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
+++ b/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
@@ -34,7 +34,9 @@ final class CustomMappingsTests: XCTestCase {
                 ],
                 unit: MappedUnit(
                     hkunit: "oz",
-                    unitAlias: "ounces"
+                    unit: "oz",
+                    system: URL(string: "http://unitsofmeasure.org")!,
+                    code: "[oz_av]"
                 )
             )
         ]
@@ -71,7 +73,9 @@ final class CustomMappingsTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
-                    unit: "ounces",
+                    code: "[oz_av]",
+                    system: "http://unitsofmeasure.org",
+                    unit: "oz",
                     value: 2116.43771697482496.asFHIRDecimalPrimitive()
                 )
             )

--- a/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
+++ b/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
@@ -22,6 +22,10 @@ final class CustomMappingsTests: XCTestCase {
             end: Date()
         )
 
+        guard let ucumSystem = URL(string: "http://unitsofmeasure.org") else {
+            return
+        }
+
         let customMapping = [
             "HKQuantityTypeIdentifierBodyMass":
             HKQuantitySampleMapping(
@@ -35,7 +39,7 @@ final class CustomMappingsTests: XCTestCase {
                 unit: MappedUnit(
                     hkunit: "oz",
                     unit: "oz",
-                    system: URL(string: "http://unitsofmeasure.org")!,
+                    system: ucumSystem,
                     code: "[oz_av]"
                 )
             )

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -70,6 +70,8 @@ class HealthKitOnFHIRTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
+                    code: "mg/dL",
+                    system: "http://unitsofmeasure.org",
                     unit: "mg/dL",
                     value: 99.asFHIRDecimalPrimitive()
                 )
@@ -124,7 +126,9 @@ class HealthKitOnFHIRTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
-                    unit: "beats/min",
+                    code: "/min",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "beats/minute",
                     value: 84.asFHIRDecimalPrimitive()
                 )
             )
@@ -151,6 +155,8 @@ class HealthKitOnFHIRTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
+                    code: "%",
+                    system: "http://unitsofmeasure.org",
                     unit: "%",
                     value: 99.asFHIRDecimalPrimitive()
                 )
@@ -178,7 +184,9 @@ class HealthKitOnFHIRTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
-                    unit: "degC",
+                    code: "Cel",
+                    system: "http://unitsofmeasure.org",
+                    unit: "C",
                     value: 37.asFHIRDecimalPrimitive()
                 )
             )
@@ -188,7 +196,7 @@ class HealthKitOnFHIRTests: XCTestCase {
     func testHeightSample() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.height),
-            quantity: HKQuantity(unit: .meter(), doubleValue: 1.77)
+            quantity: HKQuantity(unit: .inch(), doubleValue: 64)
         )
         
         XCTAssertEqual(
@@ -205,8 +213,10 @@ class HealthKitOnFHIRTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
-                    unit: "m",
-                    value: 1.77.asFHIRDecimalPrimitive()
+                    code: "[in_i]",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "in",
+                    value: 64.asFHIRDecimalPrimitive()
                 )
             )
         )
@@ -215,7 +225,7 @@ class HealthKitOnFHIRTests: XCTestCase {
     func testBodyMassSample() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.bodyMass),
-            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 60)
+            quantity: HKQuantity(unit: .pound(), doubleValue: 60)
         )
         
         XCTAssertEqual(
@@ -232,7 +242,9 @@ class HealthKitOnFHIRTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
-                    unit: "kg",
+                    code: "[lb_av]",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "lbs",
                     value: 60.asFHIRDecimalPrimitive()
                 )
             )
@@ -259,7 +271,9 @@ class HealthKitOnFHIRTests: XCTestCase {
             observation.value,
             .quantity(
                 Quantity(
-                    unit: "count/min",
+                    code: "/min",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "breaths/minute",
                     value: 18.asFHIRDecimalPrimitive()
                 )
             )
@@ -293,6 +307,8 @@ class HealthKitOnFHIRTests: XCTestCase {
         XCTAssertEqual(1, observation.component?.filter {
             $0.value == .quantity(
                 Quantity(
+                    code: "mm[Hg]",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
                     unit: "mmHg",
                     value: 120.asFHIRDecimalPrimitive()
                 )
@@ -302,6 +318,8 @@ class HealthKitOnFHIRTests: XCTestCase {
         XCTAssertEqual(1, observation.component?.filter {
             $0.value == .quantity(
                 Quantity(
+                    code: "mm[Hg]",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
                     unit: "mmHg",
                     value: 80.asFHIRDecimalPrimitive()
                 )


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Map units to standardized Unified Code for Units of Measure (UCUM) codes

## :recycle: Current situation & Problem
Units need to be mapped to a standardized code system, such as [UCUM](http://unitsofmeasure.org).

## :bulb: Proposed solution
This PR updates the HealthKit type mapping to use UCUM units when generating the valueQuantity element in a FHIR observation. Other unit code systems can be used by editing the `mapping.json` file in the `Resources` folder.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

