### PR TITLE
Make the API More Type-Safe and Add API Documentation 

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Sources/HealthKitOnFHIR/HKSample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKSample+Observation.swift
@@ -24,7 +24,7 @@ extension HKSample {
     /// A FHIR observation based on the concrete subclass of `HKSample`.
     ///
     /// If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
-    /// - Parameter withMapping: A mapping to map `HKSample`s to corresponding FHIR codes and units.
+    /// - Parameter withMapping: A mapping to map `HKSample`s to corresponding FHIR observations allowing the customization of, e.g., codings and units. See ``HKSampleMapping``.
     /// - Returns: A FHIR observation based on the concrete subclass of `HKSample`.
     public func observation(withMapping mapping: HKSampleMapping = HKSampleMapping.default) throws -> Observation {
         var observation = Observation(

--- a/Sources/HealthKitOnFHIR/HKSample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HKSample+Observation.swift
@@ -31,12 +31,12 @@ extension HKSample {
             code: CodeableConcept(),
             status: FHIRPrimitive(.final)
         )
-
+        
         // Set basic elements applicable to all observations
         observation.appendIdentifier(Identifier(id: self.uuid.uuidString.asFHIRStringPrimitive()))
         observation.setEffective(startDate: self.startDate, endDate: self.endDate)
         observation.setIssued(on: Date())
-
+        
         // Set specific data based on HealthKit type
         switch self {
         case let quantitySample as HKQuantitySample:

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
@@ -21,7 +21,6 @@ public struct HKCorrelationMapping: Decodable {
     public var categories: [MappedCode]
     
     
-    
     /// An ``HKCorrelationMapping`` allows developers to customize the mapping of `HKCorrelation`s to an FHIR Observations.
     /// - Parameters:
     ///   - codings: The FHIR codings defined as ``MappedCode``s used for the specified `HKCorrelation` type

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
@@ -7,27 +7,30 @@
 //
 
 
-/// <#Description#>
+/// An ``HKCorrelationMapping`` allows developers to customize the mapping of `HKCorrelation`s to an FHIR observations.
 public struct HKCorrelationMapping: Codable {
-    /// <#Description#>
+    /// A default instance of an ``HKCorrelationMapping`` instance allowing developers to customize the ``HKCorrelationMapping``.
+    ///
+    /// The default values are loaded from the `HKSampleMapping.json` resource in the ``HealthKitOnFHIR`` Swift Package.
     public static let `default` = HKSampleMapping.default.correlationMapping
     
     
-    /// <#Description#>
-    public let codes: [MappedCode]
-    /// <#Description#>
-    public let categories: [MappedCode]
+    /// The FHIR codings defined as ``MappedCode``s used for the specified `HKCorrelation` type
+    public var codings: [MappedCode]
+    /// The FHIR categories defined as ``MappedCode``s used for the specified `HKCorrelation` type
+    public var categories: [MappedCode]
     
     
-    /// <#Description#>
+    
+    /// An ``HKCorrelationMapping`` allows developers to customize the mapping of `HKCorrelation`s to an FHIR Observations.
     /// - Parameters:
-    ///   - codes: <#codes description#>
-    ///   - categories: <#categories description#>
+    ///   - codings: The FHIR codings defined as ``MappedCode``s used for the specified `HKCorrelation` type
+    ///   - categories: The FHIR categories defined as ``MappedCode``s used for the specified `HKCorrelation` type
     public init(
-        codes: [MappedCode],
+        codings: [MappedCode],
         categories: [MappedCode]
     ) {
-        self.codes = codes
+        self.codings = codings
         self.categories = categories
     }
 }

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
@@ -6,11 +6,23 @@
 // SPDX-License-Identifier: MIT
 //
 
-public struct HKCorrelationMapping: Codable {
-    public static let `default` = HKSampleMapping.default.correlationMapping
-    public let codes: [MappedCode]
-    public let categories: [MappedCode]
 
+/// <#Description#>
+public struct HKCorrelationMapping: Codable {
+    /// <#Description#>
+    public static let `default` = HKSampleMapping.default.correlationMapping
+    
+    
+    /// <#Description#>
+    public let codes: [MappedCode]
+    /// <#Description#>
+    public let categories: [MappedCode]
+    
+    
+    /// <#Description#>
+    /// - Parameters:
+    ///   - codes: <#codes description#>
+    ///   - categories: <#categories description#>
     public init(
         codes: [MappedCode],
         categories: [MappedCode]

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
@@ -8,7 +8,7 @@
 
 
 /// An ``HKCorrelationMapping`` allows developers to customize the mapping of `HKCorrelation`s to an FHIR observations.
-public struct HKCorrelationMapping: Codable {
+public struct HKCorrelationMapping: Decodable {
     /// A default instance of an ``HKCorrelationMapping`` instance allowing developers to customize the ``HKCorrelationMapping``.
     ///
     /// The default values are loaded from the `HKSampleMapping.json` resource in the ``HealthKitOnFHIR`` Swift Package.

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
@@ -6,12 +6,23 @@
 // SPDX-License-Identifier: MIT
 //
 
+
+/// <#Description#>
 public struct HKQuantitySampleMapping: Codable {
+    /// <#Description#>
     public static let `default` = HKSampleMapping.default.quantitySampleMapping
+    
+    
+    /// <#Description#>
     public let codes: [MappedCode]
+    /// <#Description#>
     public let unit: MappedUnit
 
-
+    
+    /// <#Description#>
+    /// - Parameters:
+    ///   - codes: <#codes description#>
+    ///   - unit: <#unit description#>
     public init(
         codes: [MappedCode],
         unit: MappedUnit

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
@@ -8,7 +8,7 @@
 
 
 /// An ``HKQuantitySampleMapping`` allows developers to customize the mapping of `HKQuantitySample`s to an FHIR observations.
-public struct HKQuantitySampleMapping: Codable {
+public struct HKQuantitySampleMapping: Decodable {
     /// A default instance of an ``HKQuantitySampleMapping`` instance allowing developers to customize the ``HKQuantitySampleMapping``.
     ///
     /// The default values are loaded from the `HKSampleMapping.json` resource in the ``HealthKitOnFHIR`` Swift Package.

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
@@ -7,27 +7,29 @@
 //
 
 
-/// <#Description#>
+/// An ``HKQuantitySampleMapping`` allows developers to customize the mapping of `HKQuantitySample`s to an FHIR observations.
 public struct HKQuantitySampleMapping: Codable {
-    /// <#Description#>
+    /// A default instance of an ``HKQuantitySampleMapping`` instance allowing developers to customize the ``HKQuantitySampleMapping``.
+    ///
+    /// The default values are loaded from the `HKSampleMapping.json` resource in the ``HealthKitOnFHIR`` Swift Package.
     public static let `default` = HKSampleMapping.default.quantitySampleMapping
     
     
-    /// <#Description#>
-    public let codes: [MappedCode]
-    /// <#Description#>
-    public let unit: MappedUnit
+    /// The FHIR codings defined as ``MappedCode``s used for the specified `HKQuantitySample` type
+    public var codings: [MappedCode]
+    /// The FHIR units defined as ``MappedUnit``s used for the specified `HKQuantitySample` type
+    public var unit: MappedUnit
 
     
-    /// <#Description#>
+    /// An ``HKQuantitySampleMapping`` allows developers to customize the mapping of `HKQuantitySample`s to an FHIR observations.
     /// - Parameters:
-    ///   - codes: <#codes description#>
-    ///   - unit: <#unit description#>
+    ///   - codings: The FHIR codings defined as ``MappedCode``s used for the specified `HKQuantitySample` type
+    ///   - unit: The FHIR units defined as ``MappedUnit``s used for the specified `HKQuantitySample` type
     public init(
-        codes: [MappedCode],
+        codings: [MappedCode],
         unit: MappedUnit
     ) {
-        self.codes = codes
+        self.codings = codings
         self.unit = unit
     }
 }

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
@@ -10,8 +10,8 @@
 /// A ``HKSampleMapping`` instance is used to specify the mapping of ``HKSample``s to FHIR observations allowing the customization of, e.g., codings and units.
 public struct HKSampleMapping: Decodable {
     private enum CodingKeys: String, CodingKey {
-        case quantitySampleMapping = "HKQuantitySample"
-        case correlationMapping = "HKCorrelation"
+        case quantitySampleMapping = "HKQuantitySamples"
+        case correlationMapping = "HKCorrelations"
     }
     
     
@@ -23,24 +23,41 @@ public struct HKSampleMapping: Decodable {
     }()
     
     
-    /// The ``HKSampleMapping/quantitySampleMapping`` property defines the mapping of `HKQuantitySample`s to FHIR observations.
-    /// ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKQuantityType` using its `identifier` property.
-    public var quantitySampleMapping: [String: HKQuantitySampleMapping]
-    /// The ``HKSampleMapping/correlationMapping`` property defines the mapping of `HKCorrelation`s to FHIR observations.
-    /// ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKCorrelationType` using its `identifier` property.
-    public var correlationMapping: [String: HKCorrelationMapping]
+    /// The ``HKSampleMapping/quantitySampleMapping`` property defines the mapping of `HKQuantityType`s to FHIR observations.
+    public var quantitySampleMapping: [HKQuantityType: HKQuantitySampleMapping]
+    /// The ``HKSampleMapping/correlationMapping`` property defines the mapping of `HKCorrelationType`s to FHIR observations.
+    public var correlationMapping: [HKCorrelationType: HKCorrelationMapping]
     
     
     public init(from decoder: Decoder) throws {
         let mappings = try decoder.container(keyedBy: CodingKeys.self)
-        let quantitySampleMapping = try mappings.decode(
-            Dictionary<String, HKQuantitySampleMapping>.self,
+        let quantityStringBasedSampleMapping = try mappings.decode(
+            [String: HKQuantitySampleMapping].self,
             forKey: .quantitySampleMapping
         )
-        let correlationMapping = try mappings.decode(
-            Dictionary<String, HKCorrelationMapping>.self,
+        let quantitySampleMapping = Dictionary(
+            uniqueKeysWithValues: quantityStringBasedSampleMapping.map { mapping in
+                guard let hkquantityType = HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: mapping.key)) else {
+                    fatalError("HKQuantityType for the String value \(mapping.key) does not exist. Please inspect your configuration.")
+                }
+                return (hkquantityType, mapping.value)
+            }
+        )
+        
+        let correlationStringBasedMapping = try mappings.decode(
+            [String: HKCorrelationMapping].self,
             forKey: .correlationMapping
         )
+        
+        let correlationMapping = Dictionary(
+            uniqueKeysWithValues: correlationStringBasedMapping.map { mapping in
+                guard let hkcorrelationType = HKCorrelationType.correlationType(forIdentifier: HKCorrelationTypeIdentifier(rawValue: mapping.key)) else {
+                    fatalError("HKCorrelationType for the String value \(mapping.key) does not exist. Please inspect your configuration.")
+                }
+                return (hkcorrelationType, mapping.value)
+            }
+        )
+        
         self.init(
             quantitySampleMapping: quantitySampleMapping,
             correlationMapping: correlationMapping
@@ -49,26 +66,13 @@ public struct HKSampleMapping: Decodable {
     
     /// A ``HKSampleMapping`` instance is used to specify the mapping of ``HKSample``s to FHIR observations allowing the customization of, e.g., codings and units.
     /// - Parameters:
-    ///   - quantitySampleMapping: The ``HKSampleMapping/quantitySampleMapping`` property defines the mapping of `HKQuantitySample`s to FHIR observations.
-    ///                            ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKQuantityType` using its `identifier` property.
-    ///   - correlationMapping: The ``HKSampleMapping/correlationMapping`` property defines the mapping of `HKCorrelation`s to FHIR observations.
-    ///                         ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKCorrelationType` using its `identifier` property.
+    ///   - quantitySampleMapping: The ``HKSampleMapping/quantitySampleMapping`` property defines the mapping of `HKQuantityType`s to FHIR observations.
+    ///   - correlationMapping: The ``HKSampleMapping/correlationMapping`` property defines the mapping of `HKCorrelationType`s to FHIR observations.
     public init(
-        quantitySampleMapping: [String: HKQuantitySampleMapping] = HKQuantitySampleMapping.default,
-        correlationMapping: [String: HKCorrelationMapping] = HKCorrelationMapping.default
+        quantitySampleMapping: [HKQuantityType: HKQuantitySampleMapping] = HKQuantitySampleMapping.default,
+        correlationMapping: [HKCorrelationType: HKCorrelationMapping] = HKCorrelationMapping.default
     ) {
-        for mapping in quantitySampleMapping {
-            guard HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: mapping.key)) != nil else {
-                fatalError("HKQuantityType for the String value \(mapping.key) does not exist. Please inspect your configuration.")
-            }
-        }
         self.quantitySampleMapping = quantitySampleMapping
-        
-        for mapping in correlationMapping {
-            guard HKCorrelationType.correlationType(forIdentifier: HKCorrelationTypeIdentifier(rawValue: mapping.key)) != nil else {
-                fatalError("HKCorrelationType for the String value \(mapping.key) does not exist. Please inspect your configuration.")
-            }
-        }
         self.correlationMapping = correlationMapping
     }
 }

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
@@ -7,7 +7,7 @@
 //
 
 
-/// <#Description#>
+/// A ``HKSampleMapping`` instance is used to specify the mapping of ``HKSample``s to FHIR observations allowing the customization of, e.g., codings and units.
 public struct HKSampleMapping: Decodable {
     private enum CodingKeys: String, CodingKey {
         case quantitySampleMapping = "HKQuantitySample"
@@ -15,16 +15,20 @@ public struct HKSampleMapping: Decodable {
     }
     
     
-    /// <#Description#>
+    /// A default instance of an ``HKSampleMapping`` instance allowing developers to customize the ``HKSampleMapping``.
+    ///
+    /// The default values are loaded from the `HKSampleMapping.json` resource in the ``HealthKitOnFHIR`` Swift Package.
     public static let `default`: HKSampleMapping = {
         Bundle.module.decode(HKSampleMapping.self, from: "HKSampleMapping.json")
     }()
     
     
-    /// <#Description#>
-    public let quantitySampleMapping: [String: HKQuantitySampleMapping]
-    /// <#Description#>
-    public let correlationMapping: [String: HKCorrelationMapping]
+    /// The ``HKSampleMapping/quantitySampleMapping`` property defines the mapping of `HKQuantitySample`s to FHIR observations.
+    /// ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKQuantityType` using its `identifier` property.
+    public var quantitySampleMapping: [String: HKQuantitySampleMapping]
+    /// The ``HKSampleMapping/correlationMapping`` property defines the mapping of `HKCorrelation`s to FHIR observations.
+    /// ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKCorrelationType` using its `identifier` property.
+    public var correlationMapping: [String: HKCorrelationMapping]
     
     
     public init(from decoder: Decoder) throws {
@@ -43,10 +47,12 @@ public struct HKSampleMapping: Decodable {
         )
     }
     
-    /// <#Description#>
+    /// A ``HKSampleMapping`` instance is used to specify the mapping of ``HKSample``s to FHIR observations allowing the customization of, e.g., codings and units.
     /// - Parameters:
-    ///   - quantitySampleMapping: <#quantitySampleMapping description#>
-    ///   - correlationMapping: <#correlationMapping description#>
+    ///   - quantitySampleMapping: The ``HKSampleMapping/quantitySampleMapping`` property defines the mapping of `HKQuantitySample`s to FHIR observations.
+    ///                            ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKQuantityType` using its `identifier` property.
+    ///   - correlationMapping: The ``HKSampleMapping/correlationMapping`` property defines the mapping of `HKCorrelation`s to FHIR observations.
+    ///                         ``HealthKitOnFHIR`` uses the string keys to identify the correct `HKCorrelationType` using its `identifier` property.
     public init(
         quantitySampleMapping: [String: HKQuantitySampleMapping] = HKQuantitySampleMapping.default,
         correlationMapping: [String: HKCorrelationMapping] = HKCorrelationMapping.default

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
@@ -51,7 +51,8 @@ public struct HKSampleMapping: Decodable {
         
         let correlationMapping = Dictionary(
             uniqueKeysWithValues: correlationStringBasedMapping.map { mapping in
-                guard let hkcorrelationType = HKCorrelationType.correlationType(forIdentifier: HKCorrelationTypeIdentifier(rawValue: mapping.key)) else {
+                let hkcorrelationTypeIdentifier = HKCorrelationTypeIdentifier(rawValue: mapping.key)
+                guard let hkcorrelationType = HKCorrelationType.correlationType(forIdentifier: hkcorrelationTypeIdentifier) else {
                     fatalError("HKCorrelationType for the String value \(mapping.key) does not exist. Please inspect your configuration.")
                 }
                 return (hkcorrelationType, mapping.value)

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
@@ -6,19 +6,27 @@
 // SPDX-License-Identifier: MIT
 //
 
+
+/// <#Description#>
 public struct HKSampleMapping: Decodable {
     private enum CodingKeys: String, CodingKey {
         case quantitySampleMapping = "HKQuantitySample"
         case correlationMapping = "HKCorrelation"
     }
-
+    
+    
+    /// <#Description#>
     public static let `default`: HKSampleMapping = {
         Bundle.module.decode(HKSampleMapping.self, from: "HKSampleMapping.json")
     }()
-
+    
+    
+    /// <#Description#>
     public let quantitySampleMapping: [String: HKQuantitySampleMapping]
+    /// <#Description#>
     public let correlationMapping: [String: HKCorrelationMapping]
-
+    
+    
     public init(from decoder: Decoder) throws {
         let mappings = try decoder.container(keyedBy: CodingKeys.self)
         let quantitySampleMapping = try mappings.decode(
@@ -34,7 +42,11 @@ public struct HKSampleMapping: Decodable {
             correlationMapping: correlationMapping
         )
     }
-
+    
+    /// <#Description#>
+    /// - Parameters:
+    ///   - quantitySampleMapping: <#quantitySampleMapping description#>
+    ///   - correlationMapping: <#correlationMapping description#>
     public init(
         quantitySampleMapping: [String: HKQuantitySampleMapping] = HKQuantitySampleMapping.default,
         correlationMapping: [String: HKCorrelationMapping] = HKCorrelationMapping.default
@@ -45,7 +57,7 @@ public struct HKSampleMapping: Decodable {
             }
         }
         self.quantitySampleMapping = quantitySampleMapping
-
+        
         for mapping in correlationMapping {
             guard HKCorrelationType.correlationType(forIdentifier: HKCorrelationTypeIdentifier(rawValue: mapping.key)) != nil else {
                 fatalError("HKCorrelationType for the String value \(mapping.key) does not exist. Please inspect your configuration.")

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
@@ -10,7 +10,7 @@ import ModelsR4
 
 
 /// A ``MappedCode`` instance is used to specify codings for FHIR observations mapped from HealthKit's `HKSample`s.
-public struct MappedCode: Codable {
+public struct MappedCode: Decodable {
     /// The identifying code.
     public var code: String
     /// A display value for the code.

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
@@ -11,32 +11,32 @@ import ModelsR4
 
 /// A ``MappedCode`` instance is used to specify codings for FHIR observations mapped from HealthKit's `HKSample`s.
 public struct MappedCode: Decodable {
-    /// The identifying code.
+    /// Symbol in syntax defined by the system.
     public var code: String
-    /// A display value for the code.
+    /// Representation defined by the system.
     public var display: String
-    /// The coding system.
-    public var system: String
+    /// Identity of the terminology system.
+    public var system: URL
     
     
     var coding: Coding {
         Coding(
             code: code.asFHIRStringPrimitive(),
             display: display.asFHIRStringPrimitive(),
-            system: FHIRPrimitive(FHIRURI(stringLiteral: system))
+            system: FHIRPrimitive(FHIRURI(system))
         )
     }
-    
+
     
     /// A ``MappedCode`` instance is used to specify codings for FHIR observations mapped from HealthKit's `HKSample`s.
     /// - Parameters:
-    ///   - code: The identifying code.
-    ///   - display: A display value for the code.
-    ///   - system: The coding system.
+    ///   - code: Symbol in syntax defined by the system.
+    ///   - display: Representation defined by the system.
+    ///   - system: Identity of the terminology system.
     public init(
         code: String,
         display: String,
-        system: String
+        system: URL
     ) {
         self.code = code
         self.display = display

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
@@ -6,12 +6,22 @@
 // SPDX-License-Identifier: MIT
 //
 
+
+/// <#Description#>
 public struct MappedCode: Codable {
+    /// <#Description#>
     public let code: String
+    /// <#Description#>
     public let display: String
+    /// <#Description#>
     public let system: String
-
-
+    
+    
+    /// <#Description#>
+    /// - Parameters:
+    ///   - code: <#code description#>
+    ///   - display: <#display description#>
+    ///   - system: <#system description#>
     public init(
         code: String,
         display: String,

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedCode.swift
@@ -6,22 +6,33 @@
 // SPDX-License-Identifier: MIT
 //
 
+import ModelsR4
 
-/// <#Description#>
+
+/// A ``MappedCode`` instance is used to specify codings for FHIR observations mapped from HealthKit's `HKSample`s.
 public struct MappedCode: Codable {
-    /// <#Description#>
-    public let code: String
-    /// <#Description#>
-    public let display: String
-    /// <#Description#>
-    public let system: String
+    /// The identifying code.
+    public var code: String
+    /// A display value for the code.
+    public var display: String
+    /// The coding system.
+    public var system: String
     
     
-    /// <#Description#>
+    var coding: Coding {
+        Coding(
+            code: code.asFHIRStringPrimitive(),
+            display: display.asFHIRStringPrimitive(),
+            system: FHIRPrimitive(FHIRURI(stringLiteral: system))
+        )
+    }
+    
+    
+    /// A ``MappedCode`` instance is used to specify codings for FHIR observations mapped from HealthKit's `HKSample`s.
     /// - Parameters:
-    ///   - code: <#code description#>
-    ///   - display: <#display description#>
-    ///   - system: <#system description#>
+    ///   - code: The identifying code.
+    ///   - display: A display value for the code.
+    ///   - system: The coding system.
     public init(
         code: String,
         display: String,

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -6,31 +6,40 @@
 // SPDX-License-Identifier: MIT
 //
 
+
+/// <#Description#>
 public struct MappedUnit: Codable {
     private enum CodingKeys: String, CodingKey {
         case hkunit
         case unitAlias
     }
-
+    
+    
+    /// <#Description#>
     public let hkunit: String
+    /// <#Description#>
     public let unitAlias: String?
-
-
+    
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         let hkunit = try values.decode(String.self, forKey: .hkunit)
         let unitAlias = try values.decodeIfPresent(String.self, forKey: .unitAlias)
-
+        
         self.init(hkunit: hkunit, unitAlias: unitAlias)
     }
-
+    
+    /// <#Description#>
+    /// - Parameters:
+    ///   - hkunit: <#hkunit description#>
+    ///   - unitAlias: <#unitAlias description#>
     public init(
         hkunit: String,
         unitAlias: String?
     ) {
         // Unfortunately this method throws an Objective-C exception when an error occurs, we can not catch this here.
         _ = HKUnit(from: hkunit)
-
+        
         self.hkunit = hkunit
         self.unitAlias = unitAlias
     }

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -8,15 +8,15 @@
 
 
 /// A ``MappedUnit`` instance is used to specify a unit mapping for FHIR observations mapped from HealthKit's `HKUnit`s.
-public struct MappedUnit: Codable {
+public struct MappedUnit: Decodable {
     private enum CodingKeys: String, CodingKey {
         case hkunit
         case unitAlias
     }
     
     
-    /// The specified `HKUnit`'s string value that should be mapped.
-    public var hkunit: String
+    /// The specified `HKUnit` that should be mapped.
+    public var hkunit: HKUnit
     /// The unit alias that is used for the FHIR obseration.
     public var unitAlias: String?
     
@@ -24,7 +24,7 @@ public struct MappedUnit: Codable {
     
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        let hkunit = try values.decode(String.self, forKey: .hkunit)
+        let hkunit = try HKUnit(from: values.decode(String.self, forKey: .hkunit))
         let unitAlias = try values.decodeIfPresent(String.self, forKey: .unitAlias)
         
         self.init(hkunit: hkunit, unitAlias: unitAlias)
@@ -32,15 +32,12 @@ public struct MappedUnit: Codable {
     
     /// A ``MappedUnit`` instance is used to specify a unit mapping for FHIR observations mapped from HealthKit's `HKUnit`s.
     /// - Parameters:
-    ///   - hkunit: The specified `HKUnit`'s string value that should be mapped.
+    ///   - hkunit: The specified `HKUnit` that should be mapped.
     ///   - unitAlias: The unit alias that is used for the FHIR obseration.
     public init(
-        hkunit: String,
+        hkunit: HKUnit,
         unitAlias: String?
     ) {
-        // Unfortunately this method throws an Objective-C exception when an error occurs, we can not catch this here.
-        _ = HKUnit(from: hkunit)
-        
         self.hkunit = hkunit
         self.unitAlias = unitAlias
     }

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -21,7 +21,6 @@ public struct MappedUnit: Decodable {
     public var unitAlias: String?
     
     
-    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         let hkunit = try HKUnit(from: values.decode(String.self, forKey: .hkunit))

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -19,11 +19,11 @@ public struct MappedUnit: Decodable {
     
     /// The specified `HKUnit` that should be mapped.
     public var hkunit: HKUnit
-    /// <#Description#>
+    /// The unit.
     public let unit: String
-    /// <#Description#>
+    /// The coding system.
     public let system: URL?
-    /// <#Description#>
+    /// The identifying code.
     public let code: String?
     
     
@@ -45,9 +45,9 @@ public struct MappedUnit: Decodable {
     /// A ``MappedUnit`` instance is used to specify a unit mapping for FHIR observations mapped from HealthKit's `HKUnit`s.
     /// - Parameters:
     ///   - hkunit: The specified `HKUnit` that should be mapped.
-    ///   - unit: <#unit description#>
-    ///   - system: <#system description#>
-    ///   - code: <#code description#>
+    ///   - unit: The unit.
+    ///   - system: The coding system.
+    ///   - code: The identifying code.
     public init(
         hkunit: HKUnit,
         unit: String,

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -7,7 +7,7 @@
 //
 
 
-/// <#Description#>
+/// A ``MappedUnit`` instance is used to specify a unit mapping for FHIR observations mapped from HealthKit's `HKUnit`s.
 public struct MappedUnit: Codable {
     private enum CodingKeys: String, CodingKey {
         case hkunit
@@ -15,10 +15,11 @@ public struct MappedUnit: Codable {
     }
     
     
-    /// <#Description#>
-    public let hkunit: String
-    /// <#Description#>
-    public let unitAlias: String?
+    /// The specified `HKUnit`'s string value that should be mapped.
+    public var hkunit: String
+    /// The unit alias that is used for the FHIR obseration.
+    public var unitAlias: String?
+    
     
     
     public init(from decoder: Decoder) throws {
@@ -29,10 +30,10 @@ public struct MappedUnit: Codable {
         self.init(hkunit: hkunit, unitAlias: unitAlias)
     }
     
-    /// <#Description#>
+    /// A ``MappedUnit`` instance is used to specify a unit mapping for FHIR observations mapped from HealthKit's `HKUnit`s.
     /// - Parameters:
-    ///   - hkunit: <#hkunit description#>
-    ///   - unitAlias: <#unitAlias description#>
+    ///   - hkunit: The specified `HKUnit`'s string value that should be mapped.
+    ///   - unitAlias: The unit alias that is used for the FHIR obseration.
     public init(
         hkunit: String,
         unitAlias: String?

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -19,20 +19,26 @@ public struct MappedUnit: Decodable {
     
     /// The specified `HKUnit` that should be mapped.
     public var hkunit: HKUnit
-    /// The unit.
-    public let unit: String
-    /// The coding system.
-    public let system: URL?
-    /// The identifying code.
-    public let code: String?
+    /// Unit representation.
+    public var unit: String
+    /// Identity of the terminology system.
+    public private(set) var system: URL?
+    /// Representation defined by the system.
+    public private(set) var code: String?
     
     
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         let hkunit = try HKUnit(from: values.decode(String.self, forKey: .hkunit))
         let unit = try values.decode(String.self, forKey: .unit)
-        let system = try values.decodeIfPresent(URL.self, forKey: .system)
-        let code = try values.decodeIfPresent(String.self, forKey: .code)
+        guard let system = try values.decodeIfPresent(URL.self, forKey: .system),
+              let code = try values.decodeIfPresent(String.self, forKey: .code) else {
+            self.init(
+                hkunit: hkunit,
+                unit: unit
+            )
+            return
+        }
         
         self.init(
             hkunit: hkunit,
@@ -45,18 +51,46 @@ public struct MappedUnit: Decodable {
     /// A ``MappedUnit`` instance is used to specify a unit mapping for FHIR observations mapped from HealthKit's `HKUnit`s.
     /// - Parameters:
     ///   - hkunit: The specified `HKUnit` that should be mapped.
-    ///   - unit: The unit.
-    ///   - system: The coding system.
-    ///   - code: The identifying code.
+    ///   - unit: Unit representation.
+    public init(
+        hkunit: HKUnit,
+        unit: String
+    ) {
+        self.hkunit = hkunit
+        self.unit = unit
+    }
+    
+    /// A ``MappedUnit`` instance is used to specify a unit mapping for FHIR observations mapped from HealthKit's `HKUnit`s.
+    /// - Parameters:
+    ///   - hkunit: The specified `HKUnit` that should be mapped.
+    ///   - unit: Unit representation.
+    ///   - system: Identity of the terminology system.
+    ///   - code: Representation defined by the system.
     public init(
         hkunit: HKUnit,
         unit: String,
-        system: URL?,
-        code: String?
+        system: URL,
+        code: String
     ) {
         self.hkunit = hkunit
         self.unit = unit
         self.system = system
         self.code = code
+    }
+    
+    
+    /// Update the system and code from the ``MappedUnit`` instance.
+    /// - Parameters:
+    ///   - system: Identity of the terminology system.
+    ///   - code: Representation defined by the system.
+    mutating func update(system: URL, code: String) {
+        self.system = system
+        self.code = code
+    }
+    
+    /// Remove the system and code from the ``MappedUnit`` instance.
+    mutating func removeSystemAndCode() {
+        system = nil
+        code = nil
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
@@ -15,7 +15,7 @@ extension HKCorrelation {
         _ observation: inout Observation,
         mappings: HKSampleMapping = HKSampleMapping.default
     ) throws {
-        guard let mapping = mappings.correlationMapping[self.correlationType.identifier] else {
+        guard let mapping = mappings.correlationMapping[self.correlationType] else {
             throw HealthKitOnFHIRError.notSupported
         }
         

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
@@ -18,7 +18,7 @@ extension HKCorrelation {
         guard let mapping = mappings.correlationMapping[self.correlationType.identifier] else {
             throw HealthKitOnFHIRError.notSupported
         }
-
+        
         for coding in mapping.codes {
             observation.appendCoding(
                 Coding(
@@ -28,7 +28,7 @@ extension HKCorrelation {
                 )
             )
         }
-
+        
         for category in mapping.categories {
             observation.appendCategory(
                 CodeableConcept(coding: [
@@ -40,12 +40,12 @@ extension HKCorrelation {
                 ])
             )
         }
-
+        
         for object in self.objects {
             guard let sample = object as? HKQuantitySample else {
                 throw HealthKitOnFHIRError.notSupported
             }
-
+            
             try sample.buildQuantitySampleObservationComponent(&observation)
         }
     }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
@@ -19,25 +19,13 @@ extension HKCorrelation {
             throw HealthKitOnFHIRError.notSupported
         }
         
-        for coding in mapping.codes {
-            observation.appendCoding(
-                Coding(
-                    code: coding.code.asFHIRStringPrimitive(),
-                    display: coding.display.asFHIRStringPrimitive(),
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: coding.system))
-                )
-            )
+        for code in mapping.codings {
+            observation.appendCoding(code.coding)
         }
         
         for category in mapping.categories {
             observation.appendCategory(
-                CodeableConcept(coding: [
-                    Coding(
-                        code: category.code.asFHIRStringPrimitive(),
-                        display: category.display.asFHIRStringPrimitive(),
-                        system: FHIRPrimitive(FHIRURI(stringLiteral: category.system))
-                    )
-                ])
+                CodeableConcept(coding: [category.coding])
             )
         }
         

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -18,7 +18,7 @@ extension HKQuantitySample {
         guard let mapping: HKQuantitySampleMapping = mappings.quantitySampleMapping[self.quantityType.identifier] else {
             throw HealthKitOnFHIRError.notSupported
         }
-
+        
         for coding in mapping.codes {
             observation.appendCoding(
                 Coding(
@@ -28,10 +28,10 @@ extension HKQuantitySample {
                 )
             )
         }
-
+        
         observation.setValue(buildQuantity(mapping))
     }
-
+    
     func buildQuantitySampleObservationComponent(
         _ observation: inout Observation,
         mappings: [String: HKQuantitySampleMapping] = HKQuantitySampleMapping.default
@@ -39,12 +39,12 @@ extension HKQuantitySample {
         guard let mapping = mappings[self.quantityType.identifier] else {
             throw HealthKitOnFHIRError.notSupported
         }
-
+        
         let component = ObservationComponent(code: CodeableConcept(coding: mapping.codes as? [Coding]))
         component.value = .quantity(buildQuantity(mapping))
         observation.appendComponent(component)
     }
-
+    
     private func buildQuantity(_ mapping: HKQuantitySampleMapping) -> Quantity {
         Quantity(
             unit: (mapping.unit.unitAlias ?? mapping.unit.hkunit).asFHIRStringPrimitive(),

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -19,14 +19,8 @@ extension HKQuantitySample {
             throw HealthKitOnFHIRError.notSupported
         }
         
-        for coding in mapping.codes {
-            observation.appendCoding(
-                Coding(
-                    code: coding.code.asFHIRStringPrimitive(),
-                    display: coding.display.asFHIRStringPrimitive(),
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: coding.system))
-                )
-            )
+        for code in mapping.codings {
+            observation.appendCoding(code.coding)
         }
         
         observation.setValue(buildQuantity(mapping))
@@ -40,7 +34,7 @@ extension HKQuantitySample {
             throw HealthKitOnFHIRError.notSupported
         }
         
-        let component = ObservationComponent(code: CodeableConcept(coding: mapping.codes as? [Coding]))
+        let component = ObservationComponent(code: CodeableConcept(coding: mapping.codings as? [Coding]))
         component.value = .quantity(buildQuantity(mapping))
         observation.appendComponent(component)
     }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -15,7 +15,7 @@ extension HKQuantitySample {
         _ observation: inout Observation,
         mappings: HKSampleMapping = HKSampleMapping.default
     ) throws {
-        guard let mapping: HKQuantitySampleMapping = mappings.quantitySampleMapping[self.quantityType.identifier] else {
+        guard let mapping = mappings.quantitySampleMapping[self.quantityType] else {
             throw HealthKitOnFHIRError.notSupported
         }
         
@@ -28,9 +28,9 @@ extension HKQuantitySample {
     
     func buildQuantitySampleObservationComponent(
         _ observation: inout Observation,
-        mappings: [String: HKQuantitySampleMapping] = HKQuantitySampleMapping.default
+        mappings: [HKQuantityType: HKQuantitySampleMapping] = HKQuantitySampleMapping.default
     ) throws {
-        guard let mapping = mappings[self.quantityType.identifier] else {
+        guard let mapping = mappings[self.quantityType] else {
             throw HealthKitOnFHIRError.notSupported
         }
         
@@ -41,8 +41,8 @@ extension HKQuantitySample {
     
     private func buildQuantity(_ mapping: HKQuantitySampleMapping) -> Quantity {
         Quantity(
-            unit: (mapping.unit.unitAlias ?? mapping.unit.hkunit).asFHIRStringPrimitive(),
-            value: self.quantity.doubleValue(for: HKUnit(from: mapping.unit.hkunit)).asFHIRDecimalPrimitive()
+            unit: (mapping.unit.unitAlias ?? mapping.unit.hkunit.unitString).asFHIRStringPrimitive(),
+            value: self.quantity.doubleValue(for: mapping.unit.hkunit).asFHIRDecimalPrimitive()
         )
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantityType+Coding.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantityType+Coding.swift
@@ -19,8 +19,8 @@ extension HKQuantityType {
     
     
     /// Converts an HKQuantityType into corresponding FHIR Coding(s) based on a specified mapping
-    func codes(mappings: [String: HKQuantitySampleMapping] = HKQuantitySampleMapping.default) -> [Coding] {
-        guard let mapping = mappings[self.identifier] else {
+    func codes(mappings: [HKQuantityType: HKQuantitySampleMapping] = HKQuantitySampleMapping.default) -> [Coding] {
+        guard let mapping = mappings[self] else {
             return []
         }
         

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantityType+Coding.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantityType+Coding.swift
@@ -24,12 +24,6 @@ extension HKQuantityType {
             return []
         }
         
-        return mapping.codes.map {
-            Coding(
-                code: $0.code.asFHIRStringPrimitive(),
-                display: $0.display.asFHIRStringPrimitive(),
-                system: FHIRPrimitive(FHIRURI(stringLiteral: $0.system))
-            )
-        }
+        return mapping.codings.map(\.coding)
     }
 }

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
@@ -64,11 +64,11 @@ extension Observation {
     func appendCodings(_ codings: [Coding]) {
         appendElements(codings, to: \.code.coding)
     }
-
+    
     func appendComponent(_ component: ObservationComponent) {
         appendElement(component, to: \.component)
     }
-
+    
     func appendComponents(_ components: [ObservationComponent]) {
         appendElements(components, to: \.component)
     }

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -1,5 +1,5 @@
 {
-    "HKCorrelation": {
+    "HKCorrelations": {
         "HKCorrelationTypeIdentifierBloodPressure": {
             "codings": [{
                 "code": "85354-9",
@@ -13,7 +13,7 @@
             }]
         }
     },
-    "HKQuantitySample": {
+    "HKQuantitySamples": {
         "HKQuantityTypeIdentifierBloodGlucose": {
             "codings": [
                 {

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -1,7 +1,7 @@
 {
     "HKCorrelation": {
         "HKCorrelationTypeIdentifierBloodPressure": {
-            "codes": [{
+            "codings": [{
                 "code": "85354-9",
                 "display": "Blood pressure panel",
                 "system": "http://loinc.org"
@@ -15,7 +15,7 @@
     },
     "HKQuantitySample": {
         "HKQuantityTypeIdentifierBloodGlucose": {
-            "codes": [
+            "codings": [
                 {
                     "code": "41653-7",
                     "display": "Glucose Glucometer (BldC) [Mass/Vol]",
@@ -27,7 +27,7 @@
             }
         },
         "HKQuantityTypeIdentifierBodyMass": {
-            "codes": [
+            "codings": [
                 {
                     "code": "29463-7",
                     "display": "Body weight",
@@ -39,7 +39,7 @@
             }
         },
         "HKQuantityTypeIdentifierBloodPressureDiastolic": {
-            "codes": [
+            "codings": [
                 {
                     "code": "8867-4",
                     "display": "Diastolic blood pressure",
@@ -51,7 +51,7 @@
             }
         },
         "HKQuantityTypeIdentifierBloodPressureSystolic": {
-            "codes": [
+            "codings": [
                 {
                     "code": "8480-6",
                     "display": "Systolic blood pressure",
@@ -63,7 +63,7 @@
             }
         },
         "HKQuantityTypeIdentifierBodyTemperature": {
-            "codes": [
+            "codings": [
                 {
                     "code": "8310-5",
                     "display": "Body temperature",
@@ -75,7 +75,7 @@
             }
         },
         "HKQuantityTypeIdentifierHeartRate": {
-            "codes": [
+            "codings": [
                 {
                     "code": "8867-4",
                     "display": "Heart rate",
@@ -88,7 +88,7 @@
             }
         },
         "HKQuantityTypeIdentifierHeight": {
-            "codes": [
+            "codings": [
                 {
                     "code": "8302-2",
                     "display": "Body height",
@@ -100,7 +100,7 @@
             }
         },
         "HKQuantityTypeIdentifierOxygenSaturation": {
-            "codes": [
+            "codings": [
                 {
                     "code": "59408-5",
                     "display": "Oxygen saturation in Arterial blood by Pulse oximetry",
@@ -112,7 +112,7 @@
             }
         },
         "HKQuantityTypeIdentifierRespiratoryRate": {
-            "codes": [
+            "codings": [
                 {
                     "code": "9279-1",
                     "display": "Respiratory rate",
@@ -124,7 +124,7 @@
             }
         },
         "HKQuantityTypeIdentifierStepCount": {
-            "codes": [
+            "codings": [
                 {
                     "code": "55423-8",
                     "display": "Number of steps in unspecified time Pedometer",

--- a/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
+++ b/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
@@ -25,7 +25,7 @@ final class CustomMappingsTests: XCTestCase {
         let customMapping = [
             "HKQuantityTypeIdentifierBodyMass":
             HKQuantitySampleMapping(
-                codes: [
+                codings: [
                     MappedCode(
                         code: "SU-01",
                         display: "Stanford University",

--- a/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
+++ b/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
@@ -22,18 +22,20 @@ final class CustomMappingsTests: XCTestCase {
             end: Date()
         )
 
-        guard let ucumSystem = URL(string: "http://unitsofmeasure.org") else {
+        guard let ucumSystem = URL(string: "http://unitsofmeasure.org"),
+              let stanfordURL = URL(string: "http://stanford.edu") else {
+            XCTFail("Could not create URLs")
             return
         }
 
-        let customMapping = [
+        var customMapping = [
             HKQuantityType(.bodyMass):
             HKQuantitySampleMapping(
                 codings: [
                     MappedCode(
                         code: "SU-01",
                         display: "Stanford University",
-                        system: "http://stanford.edu"
+                        system: stanfordURL
                     )
                 ],
                 unit: MappedUnit(
@@ -44,6 +46,13 @@ final class CustomMappingsTests: XCTestCase {
                 )
             )
         ]
+        customMapping[HKQuantityType(.bodyMass)]?.unit.removeSystemAndCode()
+        XCTAssertNil(customMapping[HKQuantityType(.bodyMass)]?.unit.system)
+        XCTAssertNil(customMapping[HKQuantityType(.bodyMass)]?.unit.code)
+        
+        customMapping[HKQuantityType(.bodyMass)]?.unit.update(system: ucumSystem, code: "[oz_av]")
+        XCTAssertEqual(customMapping[HKQuantityType(.bodyMass)]?.unit.system, ucumSystem)
+        XCTAssertEqual(customMapping[HKQuantityType(.bodyMass)]?.unit.code, "[oz_av]")
 
         let hkSampleMapping = HKSampleMapping(quantitySampleMapping: customMapping)
         
@@ -68,7 +77,7 @@ final class CustomMappingsTests: XCTestCase {
                 Coding(
                     code: "SU-01",
                     display: "Stanford University",
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: "http://stanford.edu"))
+                    system: FHIRPrimitive(FHIRURI(stanfordURL))
                 )
             ]
         )

--- a/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
+++ b/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
@@ -23,7 +23,7 @@ final class CustomMappingsTests: XCTestCase {
         )
 
         let customMapping = [
-            "HKQuantityTypeIdentifierBodyMass":
+            HKQuantityType(.bodyMass):
             HKQuantitySampleMapping(
                 codings: [
                     MappedCode(
@@ -33,7 +33,7 @@ final class CustomMappingsTests: XCTestCase {
                     )
                 ],
                 unit: MappedUnit(
-                    hkunit: "oz",
+                    hkunit: .ounce(),
                     unitAlias: "ounces"
                 )
             )


### PR DESCRIPTION
# Make the API More Type-Safe and Add API Documentation 

## :recycle: Current situation & Problem
The current API uses string values for `HKQuantityType`s, `HKCorrelationType`s, and `HKUnit`s. These interfaces use runtime errors such as `fatalError` to validate the correct values of these String values. 
In addition, before we tag a first release we should have an inline code documentation in place.

## :bulb: Proposed solution
The PR adds type-safe interfaces to the APIs, reducing the amount of runtime checking and simplifying the Swift-based interface. Runtime checks are still required for decoding elements from the JSON representation. Making the properties of the configuration types mutable reduces the need to parse a JSON file and allow users to extend the functionality in a Swift-based interface without the need to copy the JSON file from the repository.
This PR also adds inline code documentation for the [HealthKitOnFHIR](https://github.com/StanfordBDHG/HealthKitOnFHIR) package.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

