### PR TITLE
Add Apple-specific quantity types

### DIFF
--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -14,6 +14,66 @@
         }
     },
     "HKQuantitySamples": {
+        "HKQuantityTypeIdentifierActiveEnergyBurned": {
+            "codings": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "41981-2",
+                    "display": "Calories burned"
+                }
+            ],
+            "unit": {
+                "hkunit": "kcal",
+                "unit": "kcal",
+                "system": "http://unitsofmeasure.org",
+                "code": "kcal"
+            }
+        },
+        "HKQuantityTypeIdentifierAppleExerciseTime" : {
+            "codings": [
+                {
+                    "system": "https://developer.apple.com/documentation/healthkit",
+                    "code": "HKQuantityTypeIdentifierAppleExerciseTime",
+                    "display": "Apple Exercise Time"
+                }
+            ],
+            "unit": {
+                "hkunit": "min",
+                "unit": "min",
+                "system": "http://unitsofmeasure.org",
+                "code": "min"
+            }
+        },
+        "HKQuantityTypeIdentifierAppleMoveTime" : {
+            "codings": [
+                {
+                    "system": "https://developer.apple.com/documentation/healthkit",
+                    "code": "HKQuantityTypeIdentifierAppleMoveTime",
+                    "display": "Apple Move Time"
+                }
+            ],
+            "unit": {
+                "hkunit": "min",
+                "unit": "min",
+                "system": "http://unitsofmeasure.org",
+                "code": "min"
+            }
+        },
+        "HKQuantityTypeIdentifierAppleStandTime" : {
+            "codings": [
+                {
+                    "system": "https://developer.apple.com/documentation/healthkit",
+                    "code": "HKQuantityTypeIdentifierAppleStandTime",
+                    "display": "Apple Stand Time"
+                }
+            ],
+            "unit": {
+                "hkunit": "min",
+                "unit": "min",
+                "system": "http://unitsofmeasure.org",
+                "code": "min"
+            }
+        },
         "HKQuantityTypeIdentifierBloodGlucose": {
             "codings": [
                 {
@@ -89,6 +149,51 @@
                 "code": "Cel"
             }
         },
+        "HKQuantityTypeIdentifierDietaryEnergyConsumed": {
+            "codings": [
+                {
+                    "code": "9052-2",
+                    "display": "Calorie intake total",
+                    "system": "http://loinc.org"
+                }
+            ],
+            "unit": {
+                "hkunit": "kcal",
+                "unit": "kcal",
+                "system": "http://unitsofmeasure.org",
+                "code": "kcal"
+            }
+        },
+        "HKQuantityTypeIdentifierEnvironmentalAudioExposure": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierEnvironmentalAudioExposure",
+                    "display": "Environmental Audio Exposure",
+                    "system": "https://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "dBASPL",
+                "unit": "dB(SPL)",
+                "system": "http://unitsofmeasure.org",
+                "code": "dB(SPL)"
+            }
+        },
+        "HKQuantityTypeIdentifierHeadphoneAudioExposure": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierHeadphoneAudioExposure",
+                    "display": "Headphone Audio Exposure",
+                    "system": "https://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "dBASPL",
+                "unit": "dB(SPL)",
+                "system": "http://unitsofmeasure.org",
+                "code": "dB(SPL)"
+            }
+        },
         "HKQuantityTypeIdentifierHeartRate": {
             "codings": [
                 {
@@ -102,6 +207,21 @@
                 "unit": "beats/minute",
                 "system": "http://unitsofmeasure.org",
                 "code": "/min"
+            }
+        },
+        "HKQuantityTypeIdentifierHeartRateVariabilitySDNN": {
+            "codings": [
+                {
+                    "code": "80404-7",
+                    "display": "R-R interval.standard deviation (Heart rate variability)",
+                    "system": "http://loinc.org"
+                }
+            ],
+            "unit": {
+                "hkunit": "ms",
+                "unit": "ms",
+                "system": "http://unitsofmeasure.org",
+                "code": "ms"
             }
         },
         "HKQuantityTypeIdentifierHeight": {
@@ -149,6 +269,21 @@
                 "code": "/min"
             }
         },
+        "HKQuantityTypeIdentifierRestingHeartRate": {
+            "codings": [
+                {
+                    "code": "40443-4",
+                    "display": "Heart rate --resting",
+                    "system": "http://loinc.org"
+                }
+            ],
+            "unit": {
+                "hkunit": "count/min",
+                "unit": "beats/minute",
+                "system": "http://unitsofmeasure.org",
+                "code": "/min"
+            }
+        },
         "HKQuantityTypeIdentifierStepCount": {
             "codings": [
                 {
@@ -160,6 +295,21 @@
             "unit": {
                 "hkunit": "count",
                 "unit": "steps"
+            }
+        },
+        "HKQuantityTypeIdentifierWalkingHeartRateAverage": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierWalkingHeartRateAverage",
+                    "display": "Walking Heart Rate Average",
+                    "system": "https://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "count/min",
+                "unit": "beats/minute",
+                "system": "http://unitsofmeasure.org",
+                "code": "/min"
             }
         }
     }

--- a/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HealthKitOnFHIRTests.swift
@@ -49,6 +49,14 @@ class HealthKitOnFHIRTests: XCTestCase {
             system: FHIRPrimitive(FHIRURI(stringLiteral: "http://loinc.org"))
         )
     }
+
+    func appleCode(code: String, display: String) -> Coding {
+        Coding(
+            code: FHIRPrimitive(stringLiteral: code),
+            display: FHIRPrimitive(stringLiteral: display),
+            system: FHIRPrimitive(FHIRURI(stringLiteral: "https://developer.apple.com/documentation/healthkit"))
+        )
+    }
     
     func testBloodGlucose() throws {
         let observation = try createObservationFrom(
@@ -130,6 +138,93 @@ class HealthKitOnFHIRTests: XCTestCase {
                     system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
                     unit: "beats/minute",
                     value: 84.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testRestingHeartRateSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.restingHeartRate),
+            quantity: HKQuantity(unit: .count().unitDivided(by: .minute()), doubleValue: 84)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                loincCode(
+                    code: "40443-4",
+                    display: "Heart rate --resting"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "/min",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "beats/minute",
+                    value: 84.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testWalkingHeartRateAverage() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.walkingHeartRateAverage),
+            quantity: HKQuantity(unit: .count().unitDivided(by: .minute()), doubleValue: 84)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                appleCode(
+                    code: "HKQuantityTypeIdentifierWalkingHeartRateAverage",
+                    display: "Walking Heart Rate Average"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "/min",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "beats/minute",
+                    value: 84.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testHeartRateVariabilitySDNNSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.heartRateVariabilitySDNN),
+            quantity: HKQuantity(unit: .secondUnit(with: .milli), doubleValue: 100)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                loincCode(
+                    code: "80404-7",
+                    display: "R-R interval.standard deviation (Heart rate variability)"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "ms",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "ms",
+                    value: 100.asFHIRDecimalPrimitive()
                 )
             )
         )
@@ -275,6 +370,180 @@ class HealthKitOnFHIRTests: XCTestCase {
                     system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
                     unit: "breaths/minute",
                     value: 18.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testActiveEnergyBurnedSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.activeEnergyBurned),
+            quantity: HKQuantity(unit: .largeCalorie(), doubleValue: 100)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                loincCode(
+                    code: "41981-2",
+                    display: "Calories burned"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "kcal",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "kcal",
+                    value: 100.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testAppleExerciseTimeSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.appleExerciseTime),
+            quantity: HKQuantity(unit: .minute(), doubleValue: 100)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                appleCode(
+                    code: "HKQuantityTypeIdentifierAppleExerciseTime",
+                    display: "Apple Exercise Time"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "min",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "min",
+                    value: 100.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testAppleMoveTimeSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.appleMoveTime),
+            quantity: HKQuantity(unit: .minute(), doubleValue: 100)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                appleCode(
+                    code: "HKQuantityTypeIdentifierAppleMoveTime",
+                    display: "Apple Move Time"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "min",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "min",
+                    value: 100.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testAppleStandTimeSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.appleStandTime),
+            quantity: HKQuantity(unit: .minute(), doubleValue: 100)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                appleCode(
+                    code: "HKQuantityTypeIdentifierAppleStandTime",
+                    display: "Apple Stand Time"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "min",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "min",
+                    value: 100.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testEnvironmentalAudioExposureSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.environmentalAudioExposure),
+            quantity: HKQuantity(unit: .decibelAWeightedSoundPressureLevel(), doubleValue: 100)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                appleCode(
+                    code: "HKQuantityTypeIdentifierEnvironmentalAudioExposure",
+                    display: "Environmental Audio Exposure"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "dB(SPL)",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "dB(SPL)",
+                    value: 100.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+
+    func testHeadphoneAudioExposureSample() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.headphoneAudioExposure),
+            quantity: HKQuantity(unit: .decibelAWeightedSoundPressureLevel(), doubleValue: 100)
+        )
+
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                appleCode(
+                    code: "HKQuantityTypeIdentifierHeadphoneAudioExposure",
+                    display: "Headphone Audio Exposure"
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "dB(SPL)",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "dB(SPL)",
+                    value: 100.asFHIRDecimalPrimitive()
                 )
             )
         )


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Add Apple-specific quantity types

## :bulb: Proposed solution
Adds additional commonly used HealthKit quantity types including Apple-specific types such as Apple Exercise Time, Apple Stand Time, etc. In these cases, since these types cannot be mapped to existing code systems (e.g. LOINC), the resulting observation is coded using the string representation of the HealthKit type and the system URL set to the HealthKit documentation. Adds unit tests for the types added as well.

Types added are:

- ActiveEnergyBurned
- AppleExerciseTime
- AppleMoveTime
- AppleStandTime
- DietaryEnergyConsumed
- EnvironmentalAudioExposure
- HeadphoneAudioExposure
- HeartRateVariabilitySDNN
- RestingHeartRate
- WalkingHeartRateAverage


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

