### PR TITLE
Fix for path error in build-docs action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,7 +23,9 @@ jobs:
       with:
         python-version: '3.10'
     - name: Run python script
-      run: python Scripts/support_table_generator.py
+      run: |
+        cd Scripts
+        python support_table_generator.py
     - name: Commit updated files
       run: |
         git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Fix for path error in build-docs action

## :recycle: Current situation & Problem
The 'build-docs' workflow is not running due to a path error, this PR fixes it.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

