### PR TITLE
Fix/deprecated category type

### DIFF
--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -45,10 +45,10 @@
                 }
             ]
         },
-        "HKCategoryTypeIdentifierAudioExposureEvent": {
+        "HKCategoryTypeIdentifierEnvironmentalAudioExposureEvent": {
             "codings": [
                 {
-                    "code": "HKCategoryTypeIdentifierAudioExposureEvent",
+                    "code": "HKCategoryTypeIdentifierEnvironmentalAudioExposureEvent",
                     "display": "Environmental Audio Exposure Event",
                     "system": "http://developer.apple.com/documentation/healthkit"
                 }

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -45,10 +45,10 @@
                 }
             ]
         },
-        "HKCategoryTypeIdentifierEnvironmentalAudioExposureEvent": {
+        "HKCategoryTypeIdentifierAudioExposureEvent": {
             "codings": [
                 {
-                    "code": "HKCategoryTypeIdentifierEnvironmentalAudioExposureEvent",
+                    "code": "HKCategoryTypeIdentifierAudioExposureEvent",
                     "display": "Environmental Audio Exposure Event",
                     "system": "http://developer.apple.com/documentation/healthkit"
                 }

--- a/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
@@ -177,14 +177,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testEnvironmentalAudioExposureEvent() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.audioExposureEvent),
+            type: HKCategoryType(.environmentalAudioExposureEvent),
             value: HKCategoryValueEnvironmentalAudioExposureEvent.momentaryLimit.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.audioExposureEvent).description,
+                categoryType: HKCategoryType(.environmentalAudioExposureEvent).description,
                 display: "Environmental Audio Exposure Event"
             )
         )


### PR DESCRIPTION
# Fix Deprecated Category Type

## :recycle: Current situation & Problem
Addresses the following review comment thread: https://github.com/StanfordBDHG/HealthKitOnFHIR/pull/25#discussion_r1051895173

## :bulb: Proposed solution
Uses the non-deprecated version of the enum value and the corresponding string key as described in https://github.com/StanfordBDHG/HealthKitOnFHIR/pull/25#discussion_r1052483195.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

