### PR TITLE
Add HKElectrocardiogram to Observation Mapping

### DIFF
--- a/Scripts/support_table_generator.py
+++ b/Scripts/support_table_generator.py
@@ -136,6 +136,7 @@ ALL_CATEGORY_TYPES = [
     "HKCategoryTypeIdentifierDizziness",
     "HKCategoryTypeIdentifierDrySkin",
     "HKCategoryTypeIdentifierFainting",
+    "HKCategoryTypeIdentifierFatigue",
     "HKCategoryTypeIdentifierFever",
     "HKCategoryTypeIdentifierGeneralizedBodyAche",
     "HKCategoryTypeIdentifierHairLoss",

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKElectrocardiogramMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKElectrocardiogramMapping.swift
@@ -29,8 +29,8 @@ public struct HKElectrocardiogramMapping: Decodable {
     public var samplingFrequency: HKQuantitySampleMapping
     /// Defines the mapping of the `averageHeartRate` quantity property of an `HKElectrocardiogram` to a FHIR observation.
     public var averageHeartRate: HKQuantitySampleMapping
-    /// Defines the the `voltageMeasurements`'s mapping codes of an `HKElectrocardiogram`'s voltage measurements
-    public var voltageMeasurements: [MappedCode]
+    /// Defines the mapping of the `voltageMeasurements` of an `HKElectrocardiogram` to a FHIR observation.
+    public var voltageMeasurements: HKQuantitySampleMapping
     
     
     /// An ``HKCorrelationMapping`` allows developers to customize the mapping of an`HKElectrocardiogram` to a FHIR observation.
@@ -42,7 +42,7 @@ public struct HKElectrocardiogramMapping: Decodable {
     ///   - numberOfVoltageMeasurements: efines the mapping of the `numberOfVoltageMeasurements` quantity property of an `HKElectrocardiogram` to a FHIR observation.
     ///   - samplingFrequency: Defines the mapping of the `samplingFrequency` quantity property of an `HKElectrocardiogram` to a FHIR observation.
     ///   - averageHeartRate: Defines the mapping of the `averageHeartRate` quantity property of an `HKElectrocardiogram` to a FHIR observation.
-    ///   - voltageMeasurements: Defines the the `voltageMeasurements`'s mapping codes of an `HKElectrocardiogram`'s voltage measurements
+    ///   - voltageMeasurements: Defines the mapping of the `voltageMeasurements` of an `HKElectrocardiogram` to a FHIR observation.
     public init(
         codings: [MappedCode],
         categories: [MappedCode],
@@ -51,7 +51,7 @@ public struct HKElectrocardiogramMapping: Decodable {
         numberOfVoltageMeasurements: HKQuantitySampleMapping,
         samplingFrequency: HKQuantitySampleMapping,
         averageHeartRate: HKQuantitySampleMapping,
-        voltageMeasurements: [MappedCode]
+        voltageMeasurements: HKQuantitySampleMapping
     ) {
         self.codings = codings
         self.categories = categories

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKElectrocardiogramMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKElectrocardiogramMapping.swift
@@ -1,0 +1,65 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+/// An ``HKElectrocardiogramMapping`` allows developers to customize the mapping of an`HKElectrocardiogram` to a FHIR observation.
+public struct HKElectrocardiogramMapping: Decodable {
+    /// A default instance of an ``HKElectrocardiogramMapping`` instance allowing developers to customize the ``HKElectrocardiogramMapping``.
+    ///
+    /// The default values are loaded from the `HKSampleMapping.json` resource in the ``HealthKitOnFHIR`` Swift Package.
+    public static let `default` = HKSampleMapping.default.electrocardiogramMapping
+    
+    
+    /// The FHIR codings defined as ``MappedCode``s used for the `HKElectrocardiogram`.
+    public var codings: [MappedCode]
+    /// The FHIR categories defined as ``MappedCode``s used for the `HKElectrocardiogram`.
+    public var categories: [MappedCode]
+    /// Defines the mapping of the `classification` category sample  of an `HKElectrocardiogram` to a FHIR observation.
+    public var classification: HKCategorySampleMapping
+    /// Defines the mapping of the `symptomsStatus` category sample  of an `HKElectrocardiogram` to a FHIR observation.
+    public var symptomsStatus: HKCategorySampleMapping
+    /// Defines the mapping of the `numberOfVoltageMeasurements` quantity property of an `HKElectrocardiogram` to a FHIR observation.
+    public var numberOfVoltageMeasurements: HKQuantitySampleMapping
+    /// Defines the mapping of the `samplingFrequency` quantity property of an `HKElectrocardiogram` to a FHIR observation.
+    public var samplingFrequency: HKQuantitySampleMapping
+    /// Defines the mapping of the `averageHeartRate` quantity property of an `HKElectrocardiogram` to a FHIR observation.
+    public var averageHeartRate: HKQuantitySampleMapping
+    /// Defines the the `voltageMeasurements`'s mapping codes of an `HKElectrocardiogram`'s voltage measurements
+    public var voltageMeasurements: [MappedCode]
+    
+    
+    /// An ``HKCorrelationMapping`` allows developers to customize the mapping of an`HKElectrocardiogram` to a FHIR observation.
+    /// - Parameters:
+    ///   - codings: The FHIR codings defined as ``MappedCode``s used for the specified `HKElectrocardiogram`
+    ///   - categories: The FHIR categories defined as ``MappedCode``s used for the specified `HKElectrocardiogram`
+    ///   - classification: Defines the mapping of the `classification` category sample  of an `HKElectrocardiogram` to a FHIR observation.
+    ///   - symptomsStatus: Defines the mapping of the `symptomsStatus` category sample  of an `HKElectrocardiogram` to a FHIR observation.
+    ///   - numberOfVoltageMeasurements: efines the mapping of the `numberOfVoltageMeasurements` quantity property of an `HKElectrocardiogram` to a FHIR observation.
+    ///   - samplingFrequency: Defines the mapping of the `samplingFrequency` quantity property of an `HKElectrocardiogram` to a FHIR observation.
+    ///   - averageHeartRate: Defines the mapping of the `averageHeartRate` quantity property of an `HKElectrocardiogram` to a FHIR observation.
+    ///   - voltageMeasurements: Defines the the `voltageMeasurements`'s mapping codes of an `HKElectrocardiogram`'s voltage measurements
+    public init(
+        codings: [MappedCode],
+        categories: [MappedCode],
+        classification: HKCategorySampleMapping,
+        symptomsStatus: HKCategorySampleMapping,
+        numberOfVoltageMeasurements: HKQuantitySampleMapping,
+        samplingFrequency: HKQuantitySampleMapping,
+        averageHeartRate: HKQuantitySampleMapping,
+        voltageMeasurements: [MappedCode]
+    ) {
+        self.codings = codings
+        self.categories = categories
+        self.classification = classification
+        self.symptomsStatus = symptomsStatus
+        self.numberOfVoltageMeasurements = numberOfVoltageMeasurements
+        self.samplingFrequency = samplingFrequency
+        self.averageHeartRate = averageHeartRate
+        self.voltageMeasurements = voltageMeasurements
+    }
+}

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
@@ -13,6 +13,7 @@ public struct HKSampleMapping: Decodable {
         case quantitySampleMapping = "HKQuantitySamples"
         case categorySampleMapping = "HKCategorySamples"
         case correlationMapping = "HKCorrelations"
+        case electrocardiogramMapping = "HKElectrocardiogram"
     }
     
     
@@ -30,6 +31,8 @@ public struct HKSampleMapping: Decodable {
     public var categorySampleMapping: [HKCategoryType: HKCategorySampleMapping]
     /// The ``HKSampleMapping/correlationMapping`` property defines the mapping of `HKCorrelationType`s to FHIR observations.
     public var correlationMapping: [HKCorrelationType: HKCorrelationMapping]
+    /// The ``HKSampleMapping/electrocardiogramMapping`` property defines the mapping of  an`HKElectrocardiogramMapping` to a FHIR observation.
+    public var electrocardiogramMapping: HKElectrocardiogramMapping
     
     
     public init(from decoder: Decoder) throws {
@@ -76,10 +79,13 @@ public struct HKSampleMapping: Decodable {
             }
         )
         
+        let electrocardiogramMapping = try mappings.decode(HKElectrocardiogramMapping.self, forKey: .electrocardiogramMapping)
+        
         self.init(
             quantitySampleMapping: quantitySampleMapping,
             categorySampleMapping: categorySampleMapping,
-            correlationMapping: correlationMapping
+            correlationMapping: correlationMapping,
+            electrocardiogramMapping: electrocardiogramMapping
         )
     }
     
@@ -90,10 +96,12 @@ public struct HKSampleMapping: Decodable {
     public init(
         quantitySampleMapping: [HKQuantityType: HKQuantitySampleMapping] = HKQuantitySampleMapping.default,
         categorySampleMapping: [HKCategoryType: HKCategorySampleMapping] = HKCategorySampleMapping.default,
-        correlationMapping: [HKCorrelationType: HKCorrelationMapping] = HKCorrelationMapping.default
+        correlationMapping: [HKCorrelationType: HKCorrelationMapping] = HKCorrelationMapping.default,
+        electrocardiogramMapping: HKElectrocardiogramMapping = HKElectrocardiogramMapping.default
     ) {
         self.quantitySampleMapping = quantitySampleMapping
         self.categorySampleMapping = categorySampleMapping
         self.correlationMapping = correlationMapping
+        self.electrocardiogramMapping = electrocardiogramMapping
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategorySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategorySample+Observation.swift
@@ -62,6 +62,7 @@ extension HKCategorySample {
             HKCategoryType(.dizziness),
             HKCategoryType(.drySkin),
             HKCategoryType(.fainting),
+            HKCategoryType(.fatigue),
             HKCategoryType(.fever),
             HKCategoryType(.generalizedBodyAche),
             HKCategoryType(.hairLoss),

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
@@ -222,7 +222,7 @@ extension HKElectrocardiogram {
         
         // Batch the measurements in 10 Second Intervals
         let voltageMeasurementBatches = voltageMeasurements
-            .split(whereSeparator: { (time: TimeInterval, value: HKQuantity) in
+            .split(whereSeparator: { time, _ in
                 let remainder = time.remainder(dividingBy: 10.0)
                 return remainder <= period / 2
             })

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -34,7 +34,7 @@ extension HKQuantitySample {
             throw HealthKitOnFHIRError.notSupported
         }
         
-        let component = ObservationComponent(code: CodeableConcept(coding: mapping.codings as? [Coding]))
+        let component = ObservationComponent(code: CodeableConcept(coding: mapping.codings.map(\.coding)))
         component.value = .quantity(buildQuantity(mapping))
         observation.appendComponent(component)
     }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+Observation.swift
@@ -45,6 +45,8 @@ extension HKSample {
             try correlation.buildCorrelationObservation(&observation, mappings: mapping)
         case let categorySample as HKCategorySample:
             try categorySample.buildCategoryObservation(&observation)
+        case let electrocardiogram as HKElectrocardiogram:
+            try electrocardiogram.buildObservation(&observation, mappings: mapping)
         default:
             throw HealthKitOnFHIRError.notSupported
         }

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -2,8 +2,8 @@
     "HKElectrocardiogram": {
       "categories": [
         {
-          "code": "vital-signs",
-          "display": "Vital Signs",
+          "code": "procedure",
+          "display": "Procedure",
           "system": "http://terminology.hl7.org/CodeSystem/observation-category"
         }
       ],
@@ -12,6 +12,11 @@
               "code": "HKElectrocardiogram",
               "display": "Electrocardiogram",
               "system": "http://developer.apple.com/documentation/healthkit"
+          },
+          {
+              "system": "urn:oid:2.16.840.1.113883.6.24",
+              "code": "131329",
+              "display": "MDC_ECG_ELEC_POTL_I"
           }
       ],
       "classification": {
@@ -68,8 +73,8 @@
                   "system": "http://loinc.org"
               },
               {
-                  "code": "HKElectrocardiogram.NumberOfVoltageMeasurements",
-                  "display": "Average Heart Rate",
+                  "code": "HKQuantityTypeIdentifierHeartRate",
+                  "display": "Heart Rate",
                   "system": "http://developer.apple.com/documentation/healthkit"
               }
           ],
@@ -80,13 +85,21 @@
               "unit": "beats/minute"
           }
       },
-      "voltageMeasurements": [
-          {
-              "code": "HKElectrocardiogram.VoltageMeasurements",
-              "display": "Raw Voltage Measurements",
-              "system": "http://developer.apple.com/documentation/healthkit"
+      "voltageMeasurements": {
+          "codings": [
+              {
+                  "code": "131329",
+                  "system": "urn:oid:2.16.840.1.113883.6.24",
+                  "display": "MDC_ECG_ELEC_POTL_I"
+              }
+          ],
+          "unit": {
+              "code": "uV",
+              "hkunit": "mcV",
+              "system": "http://unitsofmeasure.org",
+              "unit": "uV"
           }
-      ]
+      }
     },
     "HKCategorySamples": {
         "HKCategoryTypeIdentifierAppetiteChanges": {
@@ -814,7 +827,7 @@
         "HKQuantityTypeIdentifierBloodPressureDiastolic": {
             "codings": [
                 {
-                    "code": "8867-4",
+                    "code": "8462-4",
                     "display": "Diastolic blood pressure",
                     "system": "http://loinc.org"
                 },

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -1,105 +1,105 @@
 {
     "HKElectrocardiogram": {
-      "categories": [
-        {
-          "code": "procedure",
-          "display": "Procedure",
-          "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+        "categories": [
+            {
+                "code": "procedure",
+                "display": "Procedure",
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+            }
+        ],
+        "codings": [
+            {
+                "code": "HKElectrocardiogram",
+                "display": "Electrocardiogram",
+                "system": "http://developer.apple.com/documentation/healthkit"
+            },
+            {
+                "code": "131329",
+                "display": "MDC_ECG_ELEC_POTL_I",
+                "system": "urn:oid:2.16.840.1.113883.6.24"
+            }
+        ],
+        "classification": {
+            "codings": [
+                {
+                    "code": "HKElectrocardiogram.Classification",
+                    "display": "Electrocardiogram Classification",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
+        "symptomsStatus": {
+            "codings": [
+                {
+                    "code": "HKElectrocardiogram.SymptomsStatus",
+                    "display": "Electrocardiogram Symptoms Status",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
+        "numberOfVoltageMeasurements": {
+            "codings": [
+                {
+                    "code": "HKElectrocardiogram.NumberOfVoltageMeasurements",
+                    "display": "Electrocardiogram Number of Voltage Measurements",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "count",
+                "unit": "measurements"
+            }
+        },
+        "samplingFrequency": {
+            "codings": [
+                {
+                    "code": "HKElectrocardiogram.SamplingFrequency",
+                    "display": "Sampling Frequency",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "hertz",
+                "hkunit": "Hz",
+                "system": "http://unitsofmeasure.org",
+                "unit": "hertz"
+            }
+        },
+        "averageHeartRate": {
+            "codings": [
+                {
+                    "code": "8867-4",
+                    "display": "Heart rate",
+                    "system": "http://loinc.org"
+                },
+                {
+                    "code": "HKQuantityTypeIdentifierHeartRate",
+                    "display": "Heart Rate",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "/min",
+                "hkunit": "count/min",
+                "system": "http://unitsofmeasure.org",
+                "unit": "beats/minute"
+            }
+        },
+        "voltageMeasurements": {
+            "codings": [
+                {
+                    "code": "131329",
+                    "system": "urn:oid:2.16.840.1.113883.6.24",
+                    "display": "MDC_ECG_ELEC_POTL_I"
+                }
+            ],
+            "unit": {
+                "code": "uV",
+                "hkunit": "mcV",
+                "system": "http://unitsofmeasure.org",
+                "unit": "uV"
+            }
         }
-      ],
-      "codings": [
-          {
-              "code": "HKElectrocardiogram",
-              "display": "Electrocardiogram",
-              "system": "http://developer.apple.com/documentation/healthkit"
-          },
-          {
-              "system": "urn:oid:2.16.840.1.113883.6.24",
-              "code": "131329",
-              "display": "MDC_ECG_ELEC_POTL_I"
-          }
-      ],
-      "classification": {
-          "codings": [
-              {
-                  "code": "HKElectrocardiogram.Classification",
-                  "display": "Electrocardiogram Classification",
-                  "system": "http://developer.apple.com/documentation/healthkit"
-              }
-          ]
-      },
-      "symptomsStatus": {
-          "codings": [
-              {
-                  "code": "HKElectrocardiogram.SymptomsStatus",
-                  "display": "Electrocardiogram Symptoms Status",
-                  "system": "http://developer.apple.com/documentation/healthkit"
-              }
-          ]
-      },
-      "numberOfVoltageMeasurements": {
-          "codings": [
-              {
-                  "code": "HKElectrocardiogram.NumberOfVoltageMeasurements",
-                  "display": "Electrocardiogram Number of Voltage Measurements",
-                  "system": "http://developer.apple.com/documentation/healthkit"
-              }
-          ],
-          "unit": {
-              "hkunit": "count",
-              "unit": "measurements"
-          }
-      },
-      "samplingFrequency": {
-          "codings": [
-              {
-                  "code": "HKElectrocardiogram.SamplingFrequency",
-                  "display": "Sampling Frequency",
-                  "system": "http://developer.apple.com/documentation/healthkit"
-              }
-          ],
-          "unit": {
-              "code": "hertz",
-              "hkunit": "Hz",
-              "system": "http://unitsofmeasure.org",
-              "unit": "hertz"
-          }
-      },
-      "averageHeartRate": {
-          "codings": [
-              {
-                  "code": "8867-4",
-                  "display": "Heart rate",
-                  "system": "http://loinc.org"
-              },
-              {
-                  "code": "HKQuantityTypeIdentifierHeartRate",
-                  "display": "Heart Rate",
-                  "system": "http://developer.apple.com/documentation/healthkit"
-              }
-          ],
-          "unit": {
-              "code": "/min",
-              "hkunit": "count/min",
-              "system": "http://unitsofmeasure.org",
-              "unit": "beats/minute"
-          }
-      },
-      "voltageMeasurements": {
-          "codings": [
-              {
-                  "code": "131329",
-                  "system": "urn:oid:2.16.840.1.113883.6.24",
-                  "display": "MDC_ECG_ELEC_POTL_I"
-              }
-          ],
-          "unit": {
-              "code": "uV",
-              "hkunit": "mcV",
-              "system": "http://unitsofmeasure.org",
-              "unit": "uV"
-          }
-      }
     },
     "HKCategorySamples": {
         "HKCategoryTypeIdentifierAppetiteChanges": {

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -431,6 +431,15 @@
                 }
             ]
         },
+        "HKCategoryTypeIdentifierFatigue": {
+            "codings": [
+                {
+                    "code": "HKCategoryTypeIdentifierFatigue",
+                    "display": "Fatigue",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
         "HKCategoryTypeIdentifierFever": {
             "codings": [
                 {

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -1,4 +1,93 @@
 {
+    "HKElectrocardiogram": {
+      "categories": [
+        {
+          "code": "vital-signs",
+          "display": "Vital Signs",
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+        }
+      ],
+      "codings": [
+          {
+              "code": "HKElectrocardiogram",
+              "display": "Electrocardiogram",
+              "system": "http://developer.apple.com/documentation/healthkit"
+          }
+      ],
+      "classification": {
+          "codings": [
+              {
+                  "code": "HKElectrocardiogram.Classification",
+                  "display": "Electrocardiogram Classification",
+                  "system": "http://developer.apple.com/documentation/healthkit"
+              }
+          ]
+      },
+      "symptomsStatus": {
+          "codings": [
+              {
+                  "code": "HKElectrocardiogram.SymptomsStatus",
+                  "display": "Electrocardiogram Symptoms Status",
+                  "system": "http://developer.apple.com/documentation/healthkit"
+              }
+          ]
+      },
+      "numberOfVoltageMeasurements": {
+          "codings": [
+              {
+                  "code": "HKElectrocardiogram.NumberOfVoltageMeasurements",
+                  "display": "Electrocardiogram Number of Voltage Measurements",
+                  "system": "http://developer.apple.com/documentation/healthkit"
+              }
+          ],
+          "unit": {
+              "hkunit": "count",
+              "unit": "measurements"
+          }
+      },
+      "samplingFrequency": {
+          "codings": [
+              {
+                  "code": "HKElectrocardiogram.SamplingFrequency",
+                  "display": "Sampling Frequency",
+                  "system": "http://developer.apple.com/documentation/healthkit"
+              }
+          ],
+          "unit": {
+              "code": "hertz",
+              "hkunit": "Hz",
+              "system": "http://unitsofmeasure.org",
+              "unit": "hertz"
+          }
+      },
+      "averageHeartRate": {
+          "codings": [
+              {
+                  "code": "8867-4",
+                  "display": "Heart rate",
+                  "system": "http://loinc.org"
+              },
+              {
+                  "code": "HKElectrocardiogram.NumberOfVoltageMeasurements",
+                  "display": "Average Heart Rate",
+                  "system": "http://developer.apple.com/documentation/healthkit"
+              }
+          ],
+          "unit": {
+              "code": "/min",
+              "hkunit": "count/min",
+              "system": "http://unitsofmeasure.org",
+              "unit": "beats/minute"
+          }
+      },
+      "voltageMeasurements": [
+          {
+              "code": "HKElectrocardiogram.VoltageMeasurements",
+              "display": "Raw Voltage Measurements",
+              "system": "http://developer.apple.com/documentation/healthkit"
+          }
+      ]
+    },
     "HKCategorySamples": {
         "HKCategoryTypeIdentifierAppetiteChanges": {
             "codings": [

--- a/Tests/HealthKitOnFHIRTests/HKElectrocardiogramTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKElectrocardiogramTests.swift
@@ -1,0 +1,28 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import HealthKitOnFHIR
+import XCTest
+
+
+class HKElectrocardiogramTests: XCTestCase {
+    func testElectrocardiogramCategoryTests() throws {
+        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.notSet.categoryValueDescription, "notSet")
+        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.none.categoryValueDescription, "none")
+        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.present.categoryValueDescription, "present")
+        
+        try XCTAssertEqual(HKElectrocardiogram.Classification.notSet.categoryValueDescription, "notSet")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.sinusRhythm.categoryValueDescription, "sinusRhythm")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.atrialFibrillation.categoryValueDescription, "atrialFibrillation")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveLowHeartRate.categoryValueDescription, "inconclusiveLowHeartRate")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveHighHeartRate.categoryValueDescription, "inconclusiveHighHeartRate")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusivePoorReading.categoryValueDescription, "inconclusivePoorReading")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveOther.categoryValueDescription, "inconclusiveOther")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.unrecognized.categoryValueDescription, "unrecognized")
+    }
+}

--- a/Tests/UITests/TestApp/HKElectrocardiogram+Context.swift
+++ b/Tests/UITests/TestApp/HKElectrocardiogram+Context.swift
@@ -57,4 +57,19 @@ extension HKElectrocardiogram {
         
         return symptoms
     }
+    
+    func voltageMeasurements(from healthStore: HKHealthStore) async throws -> VoltageMeasurements {
+        var voltageMeasurements: VoltageMeasurements = []
+        voltageMeasurements.reserveCapacity(numberOfVoltageMeasurements)
+        
+        let electrocardiogramQueryDescriptor = HKElectrocardiogramQueryDescriptor(self)
+        
+        for try await measurement in electrocardiogramQueryDescriptor.results(for: healthStore) {
+            if let voltageQuantity = measurement.quantity(for: .appleWatchSimilarToLeadI) {
+                voltageMeasurements.append((measurement.timeSinceSampleStart, voltageQuantity))
+            }
+        }
+        
+        return voltageMeasurements
+    }
 }

--- a/Tests/UITests/TestApp/HKElectrocardiogram+Context.swift
+++ b/Tests/UITests/TestApp/HKElectrocardiogram+Context.swift
@@ -1,0 +1,60 @@
+//
+// This source file is part of the HealthKitOnFHIR open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+import HealthKitOnFHIR
+import SwiftUI
+
+
+extension HKElectrocardiogram {
+    static let correlatedSymptomTypes: [HKCategoryType] = {
+        // We disable the SwiftLint force unwrap rule here as all initializers use Apple's constants.
+        // swiftlint:disable force_unwrapping
+        [
+            HKSampleType.categoryType(forIdentifier: HKCategoryTypeIdentifier.rapidPoundingOrFlutteringHeartbeat)!,
+            HKSampleType.categoryType(forIdentifier: HKCategoryTypeIdentifier.skippedHeartbeat)!,
+            HKSampleType.categoryType(forIdentifier: HKCategoryTypeIdentifier.fatigue)!,
+            HKSampleType.categoryType(forIdentifier: HKCategoryTypeIdentifier.shortnessOfBreath)!,
+            HKSampleType.categoryType(forIdentifier: HKCategoryTypeIdentifier.chestTightnessOrPain)!,
+            HKSampleType.categoryType(forIdentifier: HKCategoryTypeIdentifier.fainting)!,
+            HKSampleType.categoryType(forIdentifier: HKCategoryTypeIdentifier.dizziness)!
+        ]
+        // swiftlint:enable force_unwrapping
+    }()
+    
+    
+    func symptoms(from healthStore: HKHealthStore) async throws -> Symptoms {
+        let predicate = HKQuery.predicateForObjectsAssociated(electrocardiogram: self)
+        
+        try await healthStore.requestAuthorization(toShare: [], read: Set<HKObjectType>(HKElectrocardiogram.correlatedSymptomTypes))
+        
+        var symptoms: Symptoms = [:]
+        
+        if symptomsStatus == .present {
+            for sampleType in HKElectrocardiogram.correlatedSymptomTypes {
+                // Create the descriptor.
+                let sampleQueryDescriptor = HKSampleQueryDescriptor(
+                    predicates: [
+                        .sample(type: sampleType, predicate: predicate)
+                    ],
+                    sortDescriptors: [
+                        SortDescriptor(\.endDate, order: .reverse)
+                    ]
+                )
+                
+                guard let sample = try await sampleQueryDescriptor.result(for: healthStore).first,
+                      let categorySample = sample as? HKCategorySample else {
+                    continue
+                }
+                symptoms[categorySample.categoryType] = HKCategoryValueSeverity(rawValue: categorySample.value)
+            }
+        }
+        
+        return symptoms
+    }
+}

--- a/Tests/UITests/TestApp/HealthKitManager.swift
+++ b/Tests/UITests/TestApp/HealthKitManager.swift
@@ -22,7 +22,7 @@ class HealthKitManager: ObservableObject {
     }
     
     
-    func requestAuthorization() async throws {
+    func requestStepAuthorization() async throws {
         guard let healthStore,
               let stepType = HKQuantityType.quantityType(forIdentifier: .stepCount) else {
             throw HKError(.errorHealthDataUnavailable)
@@ -33,7 +33,7 @@ class HealthKitManager: ObservableObject {
     
     func readStepCount() async throws -> [HKQuantitySample] {
         guard let healthStore else {
-            return []
+            throw HKError(.errorHealthDataUnavailable)
         }
         
         let query = HKSampleQueryDescriptor(
@@ -59,5 +59,38 @@ class HealthKitManager: ObservableObject {
         )
         
         try await healthStore.save(stepsSample)
+    }
+    
+    // MARK: - Electrocardiogram
+    
+    func requestElectrocardiogramAuthorization() async throws {
+        guard let healthStore else {
+            throw HKError(.errorHealthDataUnavailable)
+        }
+        
+        var readTypes: [HKObjectType] = HKElectrocardiogram.correlatedSymptomTypes
+        readTypes.append(HKQuantityType.electrocardiogramType())
+        try await healthStore.requestAuthorization(toShare: [], read: Set(readTypes))
+    }
+    
+    func readElectrocardiogram() async throws -> HKElectrocardiogram? {
+        guard let healthStore else {
+            throw HKError(.errorHealthDataUnavailable)
+        }
+        
+        let query = HKSampleQueryDescriptor(
+            predicates: [.electrocardiogram()],
+            sortDescriptors: [],
+            limit: 1
+        )
+        
+        return try await query.result(for: healthStore).first
+    }
+    
+    func readSymptoms(for electrocardiogram: HKElectrocardiogram) async throws -> HKElectrocardiogram.Symptoms {
+        guard let healthStore else {
+            throw HKError(.errorHealthDataUnavailable)
+        }
+        return try await electrocardiogram.symptoms(from: healthStore)
     }
 }

--- a/Tests/UITests/TestApp/HealthKitManager.swift
+++ b/Tests/UITests/TestApp/HealthKitManager.swift
@@ -93,4 +93,11 @@ class HealthKitManager: ObservableObject {
         }
         return try await electrocardiogram.symptoms(from: healthStore)
     }
+    
+    func readVoltageMeasurements(for electrocardiogram: HKElectrocardiogram) async throws -> HKElectrocardiogram.VoltageMeasurements {
+        guard let healthStore else {
+            throw HKError(.errorHealthDataUnavailable)
+        }
+        return try await electrocardiogram.voltageMeasurements(from: healthStore)
+    }
 }

--- a/Tests/UITests/TestApp/Views/ContentView.swift
+++ b/Tests/UITests/TestApp/Views/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
                 Section {
                     NavigationLink("Write Data", destination: WriteDataView())
                     NavigationLink("Read Data", destination: ReadDataView())
+                    NavigationLink("Electrocardiogram", destination: ElectrocardiogramTestView())
                 }
             }
             .navigationBarTitle("HealthKitOnFHIR Tests")

--- a/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
+++ b/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
@@ -63,6 +63,36 @@ struct ElectrocardiogramTestView: View {
             voltageMeasurements: voltageMeasurements
         )
         
+        let expectedCoding = Coding(
+            code: "procedure".asFHIRStringPrimitive(),
+            display: "Procedure".asFHIRStringPrimitive(),
+            system: "http://terminology.hl7.org/CodeSystem/observation-category".asFHIRURIPrimitive()
+        )
+        guard observation?.category?.count == 1,
+              observation?.category?.first?.coding == [expectedCoding] else {
+            return
+        }
+        
+        let expectedCodes = [
+            Coding(
+                code: "HKElectrocardiogram".asFHIRStringPrimitive(),
+                display: "Electrocardiogram".asFHIRStringPrimitive(),
+                system: "http://developer.apple.com/documentation/healthkit".asFHIRURIPrimitive()
+            ),
+            Coding(
+                code: "131329".asFHIRStringPrimitive(),
+                display: "MDC_ECG_ELEC_POTL_I".asFHIRStringPrimitive(),
+                system: "urn:oid:2.16.840.1.113883.6.24".asFHIRURIPrimitive()
+            )
+        ]
+        guard observation?.code.coding == expectedCodes else {
+            return
+        }
+        
+        guard observation?.component?.count == 12 else {
+            return
+        }
+
         self.passed = true
     }
     

--- a/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
+++ b/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
@@ -1,0 +1,89 @@
+//
+// This source file is part of the HealthKitOnFHIR open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@preconcurrency import HealthKit
+import HealthKitOnFHIR
+import SwiftUI
+
+
+struct ElectrocardiogramTestView: View {
+    @StateObject private var manager = HealthKitManager()
+    
+    @State private var observation: Observation?
+    @State private var passed = false
+    @State private var json = ""
+    @State private var showingSheet = false
+    
+    
+    var body: some View {
+        Form {
+            Section {
+                Button("Read Electrocardiogram") {
+                    _Concurrency.Task {
+                        try await readElectrocardiogramTest()
+                    }
+                }
+                if passed {
+                    Text("Passed")
+                }
+                if observation != nil {
+                    Button("See JSON") {
+                        _Concurrency.Task {
+                            try readCreateJSON()
+                            showingSheet.toggle()
+                        }
+                    }
+                        .sheet(isPresented: $showingSheet) {
+                            JSONView(json: $json)
+                        }
+                }
+            }
+        }
+            .navigationBarTitle("Read Electrocardiogram")
+    }
+    
+    
+    private func readElectrocardiogramTest() async throws {
+        try await manager.requestElectrocardiogramAuthorization()
+        
+        guard let electrocardiogram = try await manager.readElectrocardiogram() else {
+            return
+        }
+        let symptoms = try await manager.readSymptoms(for: electrocardiogram)
+
+        self.observation = try electrocardiogram.observation(
+            symptoms: symptoms,
+            voltageMeasurements: URL(string: "https://stanford.edu/ecgMeasurement")
+        )
+        
+        self.passed = true
+    }
+    
+    private func readCreateJSON() throws {
+        guard let observation else {
+            return
+        }
+        
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        
+        guard let data = try? encoder.encode(observation) else {
+            return
+        }
+        
+        self.json = String(decoding: data, as: UTF8.self)
+    }
+}
+
+
+struct ElectrocardiogramTestView_Previews: PreviewProvider {
+    static var previews: some View {
+        ElectrocardiogramTestView()
+    }
+}

--- a/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
+++ b/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
@@ -56,10 +56,11 @@ struct ElectrocardiogramTestView: View {
             return
         }
         let symptoms = try await manager.readSymptoms(for: electrocardiogram)
+        let voltageMeasurements = try await manager.readVoltageMeasurements(for: electrocardiogram)
 
         self.observation = try electrocardiogram.observation(
             symptoms: symptoms,
-            voltageMeasurements: URL(string: "https://stanford.edu/ecgMeasurement")
+            voltageMeasurements: voltageMeasurements
         )
         
         self.passed = true

--- a/Tests/UITests/TestApp/Views/JSONView.swift
+++ b/Tests/UITests/TestApp/Views/JSONView.swift
@@ -11,18 +11,21 @@ import SwiftUI
 
 struct JSONView: View {
     @Environment(\.dismiss) var dismiss
-    @Binding var data: String
+    @Binding var json: String
     
     
     var body: some View {
-        VStack {
+        NavigationStack {
             ScrollView {
-                Text(data)
+                Text(json)
             }
-                .padding()
-            Button("Dismiss") {
-                dismiss()
-            }
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Dismiss") {
+                            dismiss()
+                        }
+                    }
+                }
         }
     }
 }

--- a/Tests/UITests/TestApp/Views/JSONView.swift
+++ b/Tests/UITests/TestApp/Views/JSONView.swift
@@ -34,6 +34,7 @@ struct JSONView: View {
                 }
                 .onAppear {
                     var lineNumber = 0
+                    print(json)
                     json.enumerateLines { line, _ in
                         lines.append((lineNumber, line))
                         lineNumber += 1

--- a/Tests/UITests/TestApp/Views/JSONView.swift
+++ b/Tests/UITests/TestApp/Views/JSONView.swift
@@ -12,18 +12,31 @@ import SwiftUI
 struct JSONView: View {
     @Environment(\.dismiss) var dismiss
     @Binding var json: String
+    @State var lines: [(linenumber: Int, text: String)] = []
     
     
     var body: some View {
         NavigationStack {
             ScrollView {
-                Text(json)
+                LazyVStack(alignment: .leading) {
+                    ForEach(lines, id: \.linenumber) { line in
+                        Text(line.text)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
             }
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Dismiss") {
                             dismiss()
                         }
+                    }
+                }
+                .onAppear {
+                    var lineNumber = 0
+                    json.enumerateLines { line, _ in
+                        lines.append((lineNumber, line))
+                        lineNumber += 1
                     }
                 }
         }

--- a/Tests/UITests/TestApp/Views/ReadDataView.swift
+++ b/Tests/UITests/TestApp/Views/ReadDataView.swift
@@ -27,7 +27,7 @@ struct ReadDataView: View {
                     }
                 }
                     .sheet(isPresented: $showingSheet) {
-                        JSONView(data: self.$json)
+                        JSONView(json: $json)
                     }
             }
         }
@@ -36,7 +36,7 @@ struct ReadDataView: View {
     
     
     private func readSteps() async throws {
-        try await manager.requestAuthorization()
+        try await manager.requestStepAuthorization()
         
         let observations = try await manager.readStepCount()
             .compactMap { sample in
@@ -44,7 +44,7 @@ struct ReadDataView: View {
             }
 
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         
         guard let data = try? encoder.encode(observations) else {
             return

--- a/Tests/UITests/TestApp/Views/WriteDataView.swift
+++ b/Tests/UITests/TestApp/Views/WriteDataView.swift
@@ -43,7 +43,7 @@ struct WriteDataView: View {
             return
         }
         
-        try await manager.requestAuthorization()
+        try await manager.requestStepAuthorization()
         
         try await manager.writeSteps(
             startDate: Date() - 60 * 60,

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -31,11 +31,7 @@ class TestAppUITests: XCTestCase {
         app.collectionViews.buttons["Write Step Count"].tap()
         
         // Enable Apple Health Access if needed
-        _ = app.navigationBars["Health Access"].waitForExistence(timeout: 10)
-        if app.navigationBars["Health Access"].waitForExistence(timeout: 10) {
-            app.tables.staticTexts["Turn On All"].tap()
-            app.navigationBars["Health Access"].buttons["Allow"].tap()
-        }
+        try healthKitAccess()
         
         // Check that the data is written
         sleep(2)
@@ -50,5 +46,41 @@ class TestAppUITests: XCTestCase {
         
         // Dismiss results view
         app.swipeDown(velocity: XCUIGestureVelocity.fast)
+    }
+    
+    func testECGHealthKitMapping() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        try exitAppAndOpenHealth(.electrocardiograms)
+        
+        app.collectionViews.buttons["Electrocardiogram"].tap()
+        app.collectionViews.buttons["Read Electrocardiogram"].tap()
+        
+        // Enable Apple Health Access if needed
+        try healthKitAccess()
+        
+        XCTAssert(app.staticTexts["Passed"].waitForExistence(timeout: 2))
+        
+        app.collectionViews.buttons["See JSON"].tap()
+        
+        // Dismiss results view
+        app.swipeDown(velocity: XCUIGestureVelocity.fast)
+    }
+    
+    
+    private func healthKitAccess() throws {
+        let app = XCUIApplication()
+        
+        if app.navigationBars["Health Access"].waitForExistence(timeout: 10) {
+            app.tables.staticTexts["Turn On All"].tap()
+            app.navigationBars["Health Access"].buttons["Allow"].tap()
+            return
+        }
+        print("The HealthKit View did not load after 10 seconds ... give it a second try with a timeout of 20 seconds.")
+        if app.navigationBars["Health Access"].waitForExistence(timeout: 20) {
+            app.tables.staticTexts["Turn On All"].tap()
+            app.navigationBars["Health Access"].buttons["Allow"].tap()
+        }
     }
 }

--- a/Tests/UITests/TestAppUITests/XCTTestCase+HealthDataType.swift
+++ b/Tests/UITests/TestAppUITests/XCTTestCase+HealthDataType.swift
@@ -1,0 +1,239 @@
+//
+// This source file is part of the HealthKitOnFHIR open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import XCTest
+
+
+enum HealthDataType: String {
+    case activeEnergy = "Active Energy"
+    case restingHeartRate = "Resting Heart Rate"
+    case electrocardiograms = "Electrocardiograms (ECG)"
+    case steps = "Steps"
+    case pushes = "Pushes"
+    
+    
+    struct NumberOfHKTypeNames: Equatable {
+        let activeEnergy: Int
+        let restingHeartRate: Int
+        let electrocardiograms: Int
+        let steps: Int
+        let pushes: Int
+    }
+    
+    
+    var hkTypeNames: String {
+        switch self {
+        case .activeEnergy:
+            return "HKQuantityTypeIdentifierActiveEnergyBurned"
+        case .restingHeartRate:
+            return "HKQuantityTypeIdentifierRestingHeartRate"
+        case .electrocardiograms:
+            return "HKDataTypeIdentifierElectrocardiogram"
+        case .steps:
+            return "HKQuantityTypeIdentifierStepCount"
+        case .pushes:
+            return "HKQuantityTypeIdentifierPushCount"
+        }
+    }
+    
+    var category: String {
+        switch self {
+        case .activeEnergy, .steps, .pushes:
+            return "Activity"
+        case .restingHeartRate, .electrocardiograms:
+            return "Heart"
+        }
+    }
+    
+    
+    static func numberOfHKTypeNames(in healthApp: XCUIApplication) -> NumberOfHKTypeNames {
+        NumberOfHKTypeNames(
+            activeEnergy: numberOfHKTypeNames(in: healthApp, ofType: .activeEnergy),
+            restingHeartRate: numberOfHKTypeNames(in: healthApp, ofType: .restingHeartRate),
+            electrocardiograms: numberOfHKTypeNames(in: healthApp, ofType: .electrocardiograms),
+            steps: numberOfHKTypeNames(in: healthApp, ofType: .steps),
+            pushes: numberOfHKTypeNames(in: healthApp, ofType: .pushes)
+        )
+    }
+    
+    static func numberOfHKTypeNames(in healthApp: XCUIApplication, ofType type: HealthDataType) -> Int {
+        healthApp.staticTexts.allElementsBoundByIndex.filter { $0.label.contains(type.hkTypeNames) } .count
+    }
+    
+    
+    func navigateToElement() throws {
+        let healthApp = XCUIApplication(bundleIdentifier: "com.apple.Health")
+        
+        if healthApp.navigationBars["Browse"].buttons["Cancel"].exists {
+            healthApp.navigationBars["Browse"].buttons["Cancel"].tap()
+        }
+        try findCategoryAndElement(in: healthApp)
+    }
+    
+    private func findCategoryAndElement(in healthApp: XCUIApplication) throws {
+        // Find category:
+        let categoryStaticTextPredicate = NSPredicate(format: "label CONTAINS[cd] %@", category)
+        let categoryStaticText = healthApp.staticTexts.element(matching: categoryStaticTextPredicate).firstMatch
+        
+        if categoryStaticText.waitForExistence(timeout: 20) {
+            categoryStaticText.tap()
+        } else {
+            XCTFail("Failed to find category: \(healthApp.staticTexts.allElementsBoundByIndex)")
+            throw XCTestError(.failureWhileWaiting)
+        }
+        
+        // Find element:
+        let elementStaticTextPredicate = NSPredicate(format: "label CONTAINS[cd] %@", rawValue)
+        var elementStaticText = healthApp.staticTexts.element(matching: elementStaticTextPredicate).firstMatch
+        
+        guard elementStaticText.waitForExistence(timeout: 10) else {
+            healthApp.firstMatch.swipeUp(velocity: .slow)
+            elementStaticText = healthApp.buttons.element(matching: elementStaticTextPredicate).firstMatch
+            if elementStaticText.waitForExistence(timeout: 10) {
+                elementStaticText.tap()
+                return
+            }
+            
+            healthApp.firstMatch.swipeDown(velocity: .slow)
+            elementStaticText = healthApp.buttons.element(matching: elementStaticTextPredicate).firstMatch
+            if elementStaticText.waitForExistence(timeout: 10) {
+                elementStaticText.tap()
+                return
+            }
+            
+            XCTFail("Failed to find element in category: \(healthApp.staticTexts.allElementsBoundByIndex)")
+            throw XCTestError(.failureWhileWaiting)
+        }
+        
+        elementStaticText.tap()
+    }
+    
+    func addData() {
+        let healthApp = XCUIApplication(bundleIdentifier: "com.apple.Health")
+        
+        switch self {
+        case .activeEnergy:
+            healthApp.tables.textFields["cal"].tap()
+            healthApp.tables.textFields["cal"].typeText("42")
+        case .restingHeartRate:
+            healthApp.tables.textFields["BPM"].tap()
+            healthApp.tables.textFields["BPM"].typeText("80")
+        case .electrocardiograms:
+            healthApp.tables.staticTexts["High Heart Rate"].tap()
+        case .steps:
+            healthApp.tables.textFields["Steps"].tap()
+            healthApp.tables.textFields["Steps"].typeText("42")
+        case .pushes:
+            healthApp.tables.textFields["Pushes"].tap()
+            healthApp.tables.textFields["Pushes"].typeText("42")
+        }
+    }
+}
+
+
+extension XCTestCase {
+    func exitAppAndOpenHealth(_ healthDataType: HealthDataType) throws {
+        XCUIDevice.shared.press(.home)
+        
+        addUIInterruptionMonitor(withDescription: "System Dialog") { alert in
+            guard alert.buttons["Allow"].exists else {
+                XCTFail("Failed not dismiss alert: \(alert.staticTexts.allElementsBoundByIndex)")
+                return false
+            }
+            
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        
+        let healthApp = XCUIApplication(bundleIdentifier: "com.apple.Health")
+        healthApp.terminate()
+        healthApp.activate()
+        
+        if healthApp.staticTexts["Welcome to Health"].waitForExistence(timeout: 2) {
+            handleWelcomeToHealth()
+        }
+        
+        guard healthApp.tabBars["Tab Bar"].buttons["Browse"].waitForExistence(timeout: 3) else {
+            XCTFail("Failed to identify the Add Data Button: \(healthApp.staticTexts.allElementsBoundByIndex)")
+            throw XCTestError(.failureWhileWaiting)
+        }
+        
+        healthApp.tabBars["Tab Bar"].buttons["Browse"].tap()
+        
+        try healthDataType.navigateToElement()
+        
+        guard healthApp.navigationBars.firstMatch.buttons["Add Data"].waitForExistence(timeout: 3) else {
+            XCTFail("Failed to identify the Add Data Button: \(healthApp.buttons.allElementsBoundByIndex)")
+            XCTFail("Failed to identify the Add Data Button: \(healthApp.staticTexts.allElementsBoundByIndex)")
+            throw XCTestError(.failureWhileWaiting)
+        }
+        
+        healthApp.navigationBars.firstMatch.buttons["Add Data"].tap()
+        
+        healthDataType.addData()
+        
+        guard healthApp.navigationBars.firstMatch.buttons["Add"].waitForExistence(timeout: 3) else {
+            XCTFail("Failed to identify the Add button: \(healthApp.buttons.allElementsBoundByIndex)")
+            XCTFail("Failed to identify the Add button: \(healthApp.staticTexts.allElementsBoundByIndex)")
+            throw XCTestError(.failureWhileWaiting)
+        }
+        
+        healthApp.navigationBars.firstMatch.buttons["Add"].tap()
+        
+        healthApp.terminate()
+        
+        let testApp = XCUIApplication()
+        testApp.activate()
+    }
+    
+    
+    private func handleWelcomeToHealth(alreadyRecursive: Bool = false) {
+        let healthApp = XCUIApplication(bundleIdentifier: "com.apple.Health")
+        
+        if healthApp.staticTexts["Welcome to Health"].waitForExistence(timeout: 2) {
+            XCTAssertTrue(healthApp.staticTexts["Continue"].waitForExistence(timeout: 2))
+            healthApp.staticTexts["Continue"].tap()
+            
+            XCTAssertTrue(healthApp.staticTexts["Continue"].waitForExistence(timeout: 2))
+            healthApp.staticTexts["Continue"].tap()
+            
+            XCTAssertTrue(healthApp.tables.buttons["Next"].waitForExistence(timeout: 2))
+            healthApp.tables.buttons["Next"].tap()
+            
+            // Sometimes the HealthApp fails to advance to the next step here.
+            // Go back and try again.
+            if !healthApp.staticTexts["Continue"].waitForExistence(timeout: 30) {
+                // Go one step back.
+                healthApp.navigationBars["WDBuddyFlowUserInfoView"].buttons["Back"].tap()
+                
+                XCTAssertTrue(healthApp.staticTexts["Continue"].waitForExistence(timeout: 2))
+                healthApp.staticTexts["Continue"].tap()
+                
+                // Check if the Next button exists or of the view is still in a loading process.
+                if healthApp.tables.buttons["Next"].waitForExistence(timeout: 2) {
+                    healthApp.tables.buttons["Next"].tap()
+                }
+                
+                // Continue button still doesn't exist, go for terminating the app.
+                if !healthApp.staticTexts["Continue"].waitForExistence(timeout: 30) {
+                    if alreadyRecursive {
+                        XCTFail("Even the recursive process did fail. Terminate the process.")
+                    }
+                    
+                    healthApp.terminate()
+                    healthApp.activate()
+                    handleWelcomeToHealth(alreadyRecursive: true)
+                    return
+                }
+            }
+            
+            healthApp.staticTexts["Continue"].tap()
+        }
+    }
+}

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		276501762931A58700644064 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276501752931A58700644064 /* ContentView.swift */; };
 		276501782931A82F00644064 /* ReadDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276501772931A82F00644064 /* ReadDataView.swift */; };
 		2790F40A29326CE90024213F /* JSONView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2790F40929326CE90024213F /* JSONView.swift */; };
+		2F5425F12951A9F300B5DAC2 /* XCTTestCase+HealthDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5425F02951A9F200B5DAC2 /* XCTTestCase+HealthDataType.swift */; };
+		2F5425F32951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5425F22951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift */; };
+		2F5425F62951AE2600B5DAC2 /* HKElectrocardiogram+Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5425F42951AD1D00B5DAC2 /* HKElectrocardiogram+Context.swift */; };
 		2F68C3C8292EA52000B3E12C /* HealthKitOnFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2F68C3C7292EA52000B3E12C /* HealthKitOnFHIR */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
 		2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431229130A8C005D2B8F /* TestAppUITests.swift */; };
@@ -36,6 +39,9 @@
 		2790F40929326CE90024213F /* JSONView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONView.swift; sourceTree = "<group>"; };
 		2F01E8CD291490B80089C46B /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 		2F01E8CE291493560089C46B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2F5425F02951A9F200B5DAC2 /* XCTTestCase+HealthDataType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTTestCase+HealthDataType.swift"; sourceTree = "<group>"; };
+		2F5425F22951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectrocardiogramTestView.swift; sourceTree = "<group>"; };
+		2F5425F42951AD1D00B5DAC2 /* HKElectrocardiogram+Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HKElectrocardiogram+Context.swift"; sourceTree = "<group>"; };
 		2F68C3C6292E9F8F00B3E12C /* HealthKitOnFHIR */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = HealthKitOnFHIR; path = ../..; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -88,6 +94,7 @@
 			children = (
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2765016F29319B2100644064 /* HealthKitManager.swift */,
+				2F5425F42951AD1D00B5DAC2 /* HKElectrocardiogram+Context.swift */,
 				2FBE356C29399F37002EE0D5 /* Views */,
 				2FBE356B29399ED1002EE0D5 /* Support Files */,
 			);
@@ -97,6 +104,7 @@
 		2F6D13AF28F5F386007C25D6 /* TestAppUITests */ = {
 			isa = PBXGroup;
 			children = (
+				2F5425F02951A9F200B5DAC2 /* XCTTestCase+HealthDataType.swift */,
 				2F8A431229130A8C005D2B8F /* TestAppUITests.swift */,
 			);
 			path = TestAppUITests;
@@ -126,6 +134,7 @@
 				2765017129319E3000644064 /* WriteDataView.swift */,
 				276501772931A82F00644064 /* ReadDataView.swift */,
 				2790F40929326CE90024213F /* JSONView.swift */,
+				2F5425F22951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -234,6 +243,8 @@
 			files = (
 				2790F40A29326CE90024213F /* JSONView.swift in Sources */,
 				2765017029319B2100644064 /* HealthKitManager.swift in Sources */,
+				2F5425F62951AE2600B5DAC2 /* HKElectrocardiogram+Context.swift in Sources */,
+				2F5425F32951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift in Sources */,
 				276501762931A58700644064 /* ContentView.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				276501782931A82F00644064 /* ReadDataView.swift in Sources */,
@@ -245,6 +256,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F5425F12951A9F300B5DAC2 /* XCTTestCase+HealthDataType.swift in Sources */,
 				2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
# Add HKElectrocardiogram to Observation Mapping

## :recycle: Current situation & Problem
`HKElectrocardiogram` is a commonly used HealthKit sample type that is collected using an Apple Watch or other ECG devices. 

## :bulb: Proposed solution
Adds an mapping of an ecg to an FHIR observation.
The observation uses this format as displayed in the example below.

The `component` section includes the Apple provided `HKElectrocardiogram.NumberOfVoltageMeasurements`, `HKElectrocardiogram.SamplingFrequency`, and `HKElectrocardiogram.Classification` metadata associated with an ECG.

The `component` section also includes multiple `HKCategoryType` encoded values representing the symptoms if they are passed in the `observation(symptoms: Symptoms, voltageMeasurements: VoltageMeasurements, withMapping mapping: HKSampleMapping)` function.

The `component` section also includes multiple `valueSampledData` raw voltage measurements if they are passed into the `observation(symptoms: Symptoms, voltageMeasurements: VoltageMeasurements, withMapping mapping: HKSampleMapping)` function. The raw voltage measurements are divided up into 10 second pieces.
The `valueSampledData` instances follow the FHIR specification: https://build.fhir.org/datatypes.html#sampleddata .


```json
{
  "category" : [
    {
      "coding" : [
        {
          "code" : "procedure",
          "display" : "Procedure",
          "system" : "http://terminology.hl7.org/CodeSystem/observation-category"
        }
      ]
    }
  ],
  "code" : {
    "coding" : [
      {
        "code" : "HKElectrocardiogram",
        "display" : "Electrocardiogram",
        "system" : "http://developer.apple.com/documentation/healthkit"
      },
      {
        "code" : "131329",
        "display" : "MDC_ECG_ELEC_POTL_I",
        "system" : "urn:oid:2.16.840.1.113883.6.24"
      }
    ]
  },
  "component" : [
    {
      "code" : {
        "coding" : [
          {
            "code" : "HKElectrocardiogram.NumberOfVoltageMeasurements",
            "display" : "Electrocardiogram Number of Voltage Measurements",
            "system" : "http://developer.apple.com/documentation/healthkit"
          }
        ]
      },
      "valueQuantity" : {
        "unit" : "measurements",
        "value" : 22112
      }
    },
    {
      "code" : {
        "coding" : [
          {
            "code" : "HKElectrocardiogram.SamplingFrequency",
            "display" : "Sampling Frequency",
            "system" : "http://developer.apple.com/documentation/healthkit"
          }
        ]
      },
      "valueQuantity" : {
        "code" : "hertz",
        "system" : "http://unitsofmeasure.org",
        "unit" : "hertz",
        "value" : 512
      }
    },
    {
      "code" : {
        "coding" : [
          {
            "code" : "HKElectrocardiogram.Classification",
            "display" : "Electrocardiogram Classification",
            "system" : "http://developer.apple.com/documentation/healthkit"
          }
        ]
      },
      "valueString" : "sinusRhythm"
    },
    {
      "code" : {
        "coding" : [
          {
            "code" : "8867-4",
            "display" : "Heart rate",
            "system" : "http://loinc.org"
          },
          {
            "code" : "HKQuantityTypeIdentifierHeartRate",
            "display" : "Heart Rate",
            "system" : "http://developer.apple.com/documentation/healthkit"
          }
        ]
      },
      "valueQuantity" : {
        "code" : "/min",
        "system" : "http://unitsofmeasure.org",
        "unit" : "beats/minute",
        "value" : 140
      }
    },
    {
      "code" : {
        "coding" : [
          {
            "code" : "HKElectrocardiogram.SymptomsStatus",
            "display" : "Electrocardiogram Symptoms Status",
            "system" : "http://developer.apple.com/documentation/healthkit"
          }
        ]
      },
      "valueString" : "present"
    },
    {
      "code" : {
        "coding" : [
          {
            "code" : "HKCategoryTypeIdentifierRapidPoundingOrFlutteringHeartbeat",
            "display" : "Rapid Pounding Or Fluttering Heartbeat",
            "system" : "http://developer.apple.com/documentation/healthkit"
          }
        ]
      },
      "valueString" : "unspecified"
    },
    {
      "code" : {
        "coding" : [
          {
            "code" : "HKCategoryTypeIdentifierFatigue",
            "display" : "Fatigue",
            "system" : "http://developer.apple.com/documentation/healthkit"
          }
        ]
      },
      "valueString" : "unspecified"
    },
    {
      "code" : {
        "coding" : [
          {
            "code" : "131329",
            "display" : "MDC_ECG_ELEC_POTL_I",
            "system" : "urn:oid:2.16.840.1.113883.6.24"
          }
        ]
      },
      "valueSampledData" : {
        "data" : "-122.59088134765625 -262.6523132324219 -398.10791015625 -517.7991333007812 ....",
        "dimensions" : 1,
        "origin" : {
          "code" : "uV",
          "system" : "http://unitsofmeasure.org",
          "unit" : "uV",
          "value" : 0
        },
        "period" : 0.00195303667126447232
      }
    }
  ],
  "effectivePeriod" : {
    "end" : "2022-12-20T01:41:00-08:00",
    "start" : "2022-12-20T01:41:43.1875-08:00"
  },
  "identifier" : [
    {
      "id" : "E3E98DA2-7124-4567-93CB-0B52647EA332"
    }
  ],
  "issued" : "2022-12-20T19:14:52.072656035-08:00",
  "resourceType" : "Observation",
  "status" : "final"
}
```

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

