### PR TITLE
Add HKSampleType to ResourceType

### DIFF
--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSampleType+ResourceType.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSampleType+ResourceType.swift
@@ -17,8 +17,27 @@ extension HKSampleType {
             switch self {
             case is HKQuantityType, is HKCorrelationType, is HKCategoryType:
                 return ResourceType.observation
-            case is HKClinicalType:
-                return ResourceType.resource
+            case let clinicalType as HKClinicalType:
+                switch clinicalType {
+                case HKClinicalType(.allergyRecord):
+                    return ResourceType.allergyIntolerance
+                case HKClinicalType(.conditionRecord):
+                    return ResourceType.condition
+                case HKClinicalType(.coverageRecord):
+                    return ResourceType.coverage
+                case HKClinicalType(.immunizationRecord):
+                    return ResourceType.immunization
+                case HKClinicalType(.labResultRecord):
+                    return ResourceType.observation
+                case HKClinicalType(.medicationRecord):
+                    return ResourceType.medication
+                case HKClinicalType(.procedureRecord):
+                    return ResourceType.procedure
+                case HKClinicalType(.vitalSignRecord):
+                    return ResourceType.observation
+                default:
+                    throw HealthKitOnFHIRError.notSupported
+                }
             default:
                 throw HealthKitOnFHIRError.notSupported
             }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSampleType+ResourceType.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSampleType+ResourceType.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+import ModelsR4
+
+
+extension HKSampleType {
+    /// Converts an `HKSampleType` into the corresponding FHIR resource type, defined as a `ResourceType`
+    public var resourceTyoe: ResourceType {
+        get throws {
+            switch self {
+            case is HKQuantityType, is HKCorrelationType, is HKCategoryType:
+                return ResourceType.observation
+            case is HKClinicalType:
+                return ResourceType.resource
+            default:
+                throw HealthKitOnFHIRError.notSupported
+            }
+        }
+    }
+}

--- a/Tests/HealthKitOnFHIRTests/HKSampleTypeResourceTypeMapping.swift
+++ b/Tests/HealthKitOnFHIRTests/HKSampleTypeResourceTypeMapping.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+import HealthKitOnFHIR
+import ModelsR4
+import XCTest
+
+
+class HKSampleTypeResourceTypeMapping: XCTestCase {
+    func testHKSampleTypeMappingToObservation() {
+        try XCTAssertEqual(HKQuantityType(.activeEnergyBurned).resourceTyoe, .observation)
+        try XCTAssertEqual(HKCorrelationType(.bloodPressure).resourceTyoe, .observation)
+        try XCTAssertEqual(HKCategoryType(.abdominalCramps).resourceTyoe, .observation)
+        
+        XCTAssertThrowsError(try HKSampleType.workoutType().resourceTyoe)
+    }
+    
+    func testHKClinicalTypeMappingToResourceType() throws {
+        try XCTAssertEqual(HKClinicalType(.allergyRecord).resourceTyoe, .allergyIntolerance)
+        try XCTAssertEqual(HKClinicalType(.conditionRecord).resourceTyoe, .condition)
+        try XCTAssertEqual(HKClinicalType(.coverageRecord).resourceTyoe, .coverage)
+        try XCTAssertEqual(HKClinicalType(.immunizationRecord).resourceTyoe, .immunization)
+        try XCTAssertEqual(HKClinicalType(.labResultRecord).resourceTyoe, .observation)
+        try XCTAssertEqual(HKClinicalType(.medicationRecord).resourceTyoe, .medication)
+        try XCTAssertEqual(HKClinicalType(.procedureRecord).resourceTyoe, .procedure)
+        try XCTAssertEqual(HKClinicalType(.vitalSignRecord).resourceTyoe, .observation)
+    }
+}


### PR DESCRIPTION
# Add HKSampleType to ResourceType

## :recycle: Current situation & Problem
While the HKSample extensions provide a reasonable mapping of concrete HKSamples, some mapping functionality needs to determine the corresponding resource type for an abstract HKSampleType.

## :bulb: Proposed solution
This PR adds a small extension to `HKSampleType` to determine a best-effort approach of mapping an `HKSampleType` to an `ResourceType`.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

