### PR TITLE
Assign ID Property

### DIFF
--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -31,7 +31,8 @@ extension HKSample {
         )
         
         // Set basic elements applicable to all observations
-        observation.appendIdentifier(Identifier(id: self.uuid.uuidString.asFHIRStringPrimitive()))
+        observation.id = self.uuid.uuidString.asFHIRStringPrimitive()
+        observation.appendIdentifier(Identifier(id: observation.id))
         observation.setEffective(startDate: self.startDate, endDate: self.endDate)
         observation.setIssued(on: Date())
         

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -54,8 +54,10 @@ class TestAppUITests: XCTestCase {
         
         try exitAppAndOpenHealth(.electrocardiograms)
         
-        app.collectionViews.buttons["Electrocardiogram"].tap()
-        app.collectionViews.buttons["Read Electrocardiogram"].tap()
+        XCTAssert(app.buttons["Electrocardiogram"].waitForExistence(timeout: 2))
+        app.buttons["Electrocardiogram"].tap()
+        XCTAssert(app.buttons["Read Electrocardiogram"].waitForExistence(timeout: 0.5))
+        app.buttons["Read Electrocardiogram"].tap()
         
         // Enable Apple Health Access if needed
         try healthKitAccess()


### PR DESCRIPTION
# Assign ID Property

## :recycle: Current situation & Proposed solution
The current conversion to a FHIR resource doesn't set its id property. We assign this ID property internally to the HKSample id. It can be overwritten or adapted if the FHIR resources should be uploaded to a FHIR server.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

