### PR TITLE
Fixes ECG coding

### DIFF
--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -14,8 +14,8 @@
                 "system": "http://developer.apple.com/documentation/healthkit"
             },
             {
-                "code": "131329",
-                "display": "MDC_ECG_ELEC_POTL_I",
+                "code": "131328",
+                "display": "MDC_ECG_ELEC_POTL",
                 "system": "urn:oid:2.16.840.1.113883.6.24"
             }
         ],

--- a/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
+++ b/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
@@ -81,8 +81,8 @@ struct ElectrocardiogramTestView: View {
                 system: "http://developer.apple.com/documentation/healthkit".asFHIRURIPrimitive()
             ),
             Coding(
-                code: "131329".asFHIRStringPrimitive(),
-                display: "MDC_ECG_ELEC_POTL_I".asFHIRStringPrimitive(),
+                code: "131328".asFHIRStringPrimitive(),
+                display: "MDC_ECG_ELEC_POTL".asFHIRStringPrimitive(),
                 system: "urn:oid:2.16.840.1.113883.6.24".asFHIRURIPrimitive()
             )
         ]

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -62,7 +62,7 @@ class TestAppUITests: XCTestCase {
         // Enable Apple Health Access if needed
         try healthKitAccess()
         
-        XCTAssert(app.staticTexts["Passed"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Passed"].waitForExistence(timeout: 10))
         
         app.collectionViews.buttons["See JSON"].tap()
         


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Fixes ECG coding

## :recycle: Current situation & Problem
The ECG observation has an incorrect coding.

## :bulb: Proposed solution
Fixes the ECG coding to match the example given in the FHIR R4 documentation (see: http://hl7.org/fhir/observation-example-sample-data.html)

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

