### PR TITLE
Fix ECG Batch Calculation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,22 +16,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_test-spm:
+  buildandtest:
     name: Build and Test Swift Package
-    uses: StanfordBDHG/.github/.github/workflows/build-and-test-xcodebuild-spm.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
+      artifactname: HealthKitOnFHIR.xcresult
+      runsonlabels: '["macOS", "self-hosted"]'
       scheme: HealthKitOnFHIR
-  build_and_test-uitests:
-    name: Build and Test UITest App
-    uses: StanfordBDHG/.github/.github/workflows/build-and-test-xcodebuild.yml@v1
+  buildandtestuitests:
+    name: Build and Test UI Tests
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
-      xcodeprojname: Tests/UITests/UITests.xcodeproj
+      artifactname: TestApp.xcresult
+      runsonlabels: '["macOS", "self-hosted"]'
+      path: 'Tests/UITests'
       scheme: TestApp
-  create-and-upload-coverage-report:
-    name: Create and Upload Coverage Report
-    needs: [build_and_test-spm, build_and_test-uitests]
-    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v1
+  uploadcoveragereport:
+    name: Upload Coverage Report
+    needs: [buildandtest, buildandtestuitests]
+    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: HealthKitOnFHIR.xcresult TestApp.xcresult
-    secrets:
-      token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   reuse_action:
     name: REUSE Compliance Check
-    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
   swiftlint:
     name: SwiftLint
-    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKCategorySampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKCategorySampleMapping.swift
@@ -6,6 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
+import HealthKit
+
+
 /// An ``HKCategorySampleMapping`` allows developers to customize the mapping of `HKCategorySample`s to FHIR observations.
 public struct HKCategorySampleMapping: Decodable {
     /// A default instance of an ``HKCategorySampleMapping`` instance allowing developers to customize the ``HKCategorySampleMapping``.

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKCorrelationMapping.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import HealthKit
+
 
 /// An ``HKCorrelationMapping`` allows developers to customize the mapping of `HKCorrelation`s to an FHIR observations.
 public struct HKCorrelationMapping: Decodable {

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKQuantitySampleMapping.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import HealthKit
+
 
 /// An ``HKQuantitySampleMapping`` allows developers to customize the mapping of `HKQuantitySample`s to an FHIR observations.
 public struct HKQuantitySampleMapping: Decodable {

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
@@ -231,11 +231,20 @@ extension HKElectrocardiogram {
         }
         
         // Batch the measurements in 10 Second Intervals
-        let voltageMeasurementBatches = voltageMeasurements
-            .split { time, _ in
-                let remainder = time.remainder(dividingBy: 10.0)
-                return remainder <= period / 2
+        var lastIndex = 0
+        var voltageMeasurementBatches: [[(time: TimeInterval, value: HKQuantity)]] = []
+        for voltageMeasurement in voltageMeasurements.enumerated() {
+            let remainder = voltageMeasurement.element.time.truncatingRemainder(dividingBy: 10.0)
+            if remainder <= period / 2 && lastIndex < voltageMeasurement.offset {
+                voltageMeasurementBatches.append(Array(voltageMeasurements[lastIndex..<voltageMeasurement.offset]))
+                lastIndex = voltageMeasurement.offset
             }
+        }
+        // Append the last elements that are left over (idelly exactly 10 seconds of data).
+        voltageMeasurementBatches.append(Array(voltageMeasurements[lastIndex..<voltageMeasurements.count]))
+        
+        // Check that we did not loose any data in the batching process.
+        assert(voltageMeasurements.count == voltageMeasurementBatches.reduce(0, { $0 + $1.count }))
         
         for voltageMeasurementBatch in voltageMeasurementBatches {
             // Create a space separated string of all the measurement values as defined by the mapping unit

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
@@ -240,7 +240,7 @@ extension HKElectrocardiogram {
                 lastIndex = voltageMeasurement.offset
             }
         }
-        // Append the last elements that are left over (idelly exactly 10 seconds of data).
+        // Append the last elements that are left over (ideally exactly 10 seconds of data).
         voltageMeasurementBatches.append(Array(voltageMeasurements[lastIndex..<voltageMeasurements.count]))
         
         // Check that we did not loose any data in the batching process.


### PR DESCRIPTION
# Fix ECG Batch Calculation

## :recycle: Current situation & Problem
- The current batch calculation of the ECG currently omits half of the recorded voltage measurements due to a bug that discarded the second half of the 10 second intervals.

## :bulb: Proposed solution
- This PR moves away from the split method + remainder calculation and inserts an assertion to check that the batches contain the same amount of values as the initial recoding.

### Testing
The functionality is tested using the UI test and the included assertion.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

