### PR TITLE
Support for Physical Effort Metric

### DIFF
--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -1909,6 +1909,21 @@
                 "unit": "%"
             }
         },
+        "HKQuantityTypeIdentifierPhysicalEffort": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierPhysicalEffort",
+                    "display": "Physical Effort",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "kcal/hr/kg",
+                "hkunit": "kcal/hr*kg",
+                "system": "http://unitsofmeasure.org",
+                "unit": "kcal/hr/kg"
+            }
+        },
         "HKQuantityTypeIdentifierPushCount": {
             "codings": [
                 {

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -2288,6 +2288,36 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
+    func testApplePhysicalEffort() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.physicalEffort),
+            quantity: HKQuantity(unit: HKUnit(from: "kcal/hr*kg"), doubleValue: 75)
+        )
+        
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                createCoding(
+                    code: "HKQuantityTypeIdentifierPhysicalEffort",
+                    display: "Apple Physical Effort",
+                    system: .apple
+                )
+            ]
+        )
+        
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "kcal/hr/kg",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "kcal/hr/kg",
+                    value: 2.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+    
     func testAppleStandTime() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.appleStandTime),


### PR DESCRIPTION
# Support for Physical Effort Metric

## :recycle: Current situation & Problem
Currently, HealthKitOnFHIR does not support the `HKQuantityTypeIdentifierPhysicalEffort` type, a recent addition to [HealthKit](https://developer.apple.com/documentation/healthkit). Now we are adding the ability to encode a FHIR resource related to this physical effort metric, measured in metabolic equivalents (calories per hour per kilogram).

## :gear: Release Notes
- Added support for `HKQuantityTypeIdentifierPhysicalEffort` in HealthKit extension to enable tracking of physical effort in kcal/hr/kg.

## :books: Documentation
This feature is implemented with an emphasis on maintaining consistency with existing types and ensuring that the new data can be seamlessly integrated with our tools and UI.

## :white_check_mark: Testing
See [`HKQuantitySampleTests.swift`](https://github.com/StanfordBDHG/HealthKitOnFHIR/compare/main...MatthewTurk247:HealthKitOnFHIR:feat/physical-effort?expand=1#diff-067522c16f34e0d0482be7d31057cd4b4ebb49a9b6c2d7200ec09d20a23fb769).

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).