### PR TITLE
Adds support for additional gait metrics

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,3 +37,5 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: HealthKitOnFHIR.xcresult TestApp.xcresult
+    secrets:
+      token: ${{ secrets.CODECOV_TOKEN }}

--- a/Scripts/support_table_generator.py
+++ b/Scripts/support_table_generator.py
@@ -26,6 +26,7 @@ UNSUPPORTED_SYMBOL = '❌'
 ALL_QUANTITY_TYPES = [
     "HKQuantityTypeIdentifierActiveEnergyBurned",
     "HKQuantityTypeIdentifierAppleExerciseTime",
+    "HKQuantityTypeIdentifierAppleWalkingSteadiness",
     "HKQuantityTypeIdentifierBasalBodyTemperature",
     "HKQuantityTypeIdentifierBasalEnergyBurned",
     "HKQuantityTypeIdentifierBloodAlcoholContent",
@@ -103,7 +104,8 @@ ALL_QUANTITY_TYPES = [
     "HKQuantityTypeIdentifierUVExposure",
     "HKQuantityTypeIdentifierVO2Max",
     "HKQuantityTypeIdentifierWaistCircumference",
-    "HKQuantityTypeIdentifierWalkingHeartRateAverage"
+    "HKQuantityTypeIdentifierWalkingHeartRateAverage",
+    "HKQuantityTypeIdentifierWalkingAsymmetryPercentage"
 ]
 
 ALL_CORRELATION_TYPES = [

--- a/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HKSampleSupportTables.md
+++ b/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HKSampleSupportTables.md
@@ -17,5 +17,5 @@ SPDX-License-Identifier: MIT
 - [HKClinicalType](<doc:SupportedHKClinicalTypes>)
     - HealthKitOnFHIR supports 8 of 8 clinical types.
 - [HKQuantityType](<doc:SupportedHKQuantityTypes>)
-    - HealthKitOnFHIR supports 82 of 84 quantity types.
+    - HealthKitOnFHIR supports 85 of 87 quantity types.
     

--- a/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/SupportedHKQuantityTypes.md
+++ b/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/SupportedHKQuantityTypes.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
              
 -->
 
-HealthKitOnFHIR supports 82 of 84 quantity types.
+HealthKitOnFHIR supports 85 of 87 quantity types.
 
 |HKQuantityType|Supported|Code|Unit|
 |----|----|----|----|
@@ -17,6 +17,7 @@ HealthKitOnFHIR supports 82 of 84 quantity types.
 |[AppleExerciseTime](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierAppleExerciseTime)|✅|[HKQuantityTypeIdentifierAppleExerciseTime](http://developer.apple.com/documentation/healthkit)|[min](http://unitsofmeasure.org)|
 |[AppleMoveTime](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierAppleMoveTime)|✅|[HKQuantityTypeIdentifierAppleMoveTime](http://developer.apple.com/documentation/healthkit)|[min](http://unitsofmeasure.org)|
 |[AppleStandTime](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierAppleStandTime)|✅|[HKQuantityTypeIdentifierAppleStandTime](http://developer.apple.com/documentation/healthkit)|[min](http://unitsofmeasure.org)|
+|[AppleWalkingSteadiness](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierAppleWalkingSteadiness)|✅|[HKQuantityTypeIdentifierAppleWalkingSteadiness](http://developer.apple.com/documentation/healthkit)|[%](http://unitsofmeasure.org)|
 |[BasalBodyTemperature](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierBasalBodyTemperature)|✅|[HKQuantityTypeIdentifierBasalBodyTemperature](http://developer.apple.com/documentation/healthkit)|[C](http://unitsofmeasure.org)|
 |[BasalEnergyBurned](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierBasalEnergyBurned)|✅|[HKQuantityTypeIdentifierBasalEnergyBurned](http://developer.apple.com/documentation/healthkit)|[kcal](http://unitsofmeasure.org)|
 |[BloodAlcoholContent](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierBloodAlcoholContent)|✅|[74859-0](http://loinc.org/74859-0)|[%](http://unitsofmeasure.org)|
@@ -97,4 +98,5 @@ HealthKitOnFHIR supports 82 of 84 quantity types.
 |[UVExposure](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierUVExposure)|✅|[HKQuantityTypeIdentifierUVExposure](http://developer.apple.com/documentation/healthkit)|count|
 |[VO2Max](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierVO2Max)|✅|[HKQuantityTypeIdentifierVO2Max](http://developer.apple.com/documentation/healthkit)|[mL/kg/min](http://unitsofmeasure.org)|
 |[WaistCircumference](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierWaistCircumference)|✅|[8280-0](http://loinc.org/8280-0)|[in](http://unitsofmeasure.org)|
+|[WalkingAsymmetryPercentage](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierWalkingAsymmetryPercentage)|✅|[HKQuantityTypeIdentifierWalkingAsymmetryPercentage](http://developer.apple.com/documentation/healthkit)|[%](http://unitsofmeasure.org)|
 |[WalkingHeartRateAverage](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierWalkingHeartRateAverage)|✅|[HKQuantityTypeIdentifierWalkingHeartRateAverage](http://developer.apple.com/documentation/healthkit)|[beats/minute](http://unitsofmeasure.org)|

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -775,6 +775,21 @@
                 "unit": "min"
             }
         },
+        "HKQuantityTypeIdentifierAppleWalkingSteadiness": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierAppleWalkingSteadiness",
+                    "display": "Apple Walking Steadiness",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "%",
+                "hkunit": "%",
+                "system": "http://unitsofmeasure.org",
+                "unit": "%"
+            }
+        },
         "HKQuantityTypeIdentifierBasalBodyTemperature": {
             "codings": [
                 {
@@ -2059,6 +2074,21 @@
                 "hkunit": "in",
                 "system": "http://unitsofmeasure.org",
                 "unit": "in"
+            }
+        },
+        "HKQuantityTypeIdentifierWalkingAsymmetryPercentage": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierWalkingAsymmetryPercentage",
+                    "display": "Walking Asymmetry Percentage",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "%",
+                "hkunit": "%",
+                "system": "http://unitsofmeasure.org",
+                "unit": "%"
             }
         },
         "HKQuantityTypeIdentifierWalkingHeartRateAverage": {

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -1531,6 +1531,36 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
+    func testWalkingAsymmetryPercentage() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.walkingAsymmetryPercentage),
+            quantity: HKQuantity(unit: .percent(), doubleValue: 50)
+        )
+        
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                createCoding(
+                    code: "HKQuantityTypeIdentifierWalkingAsymmetryPercentage",
+                    display: "Walking Asymmetry Percentage",
+                    system: .apple
+                )
+            ]
+        )
+        
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "%",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "%",
+                    value: 50.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+    
     func testHeartRateVariabilitySDNN() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.heartRateVariabilitySDNN),
@@ -2344,6 +2374,36 @@ class HKQuantitySampleTests: XCTestCase {
                     system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
                     unit: "min",
                     value: 100.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+    
+    func testAppleWalkingSteadiness() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.appleWalkingSteadiness),
+            quantity: HKQuantity(unit: .percent(), doubleValue: 50)
+        )
+        
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                createCoding(
+                    code: "HKQuantityTypeIdentifierAppleWalkingSteadiness",
+                    display: "Apple Walking Steadiness",
+                    system: .apple
+                )
+            ]
+        )
+        
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "%",
+                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                    unit: "%",
+                    value: 50.asFHIRDecimalPrimitive()
                 )
             )
         )


### PR DESCRIPTION
# Adds support for additional gait metrics

## :recycle: Current situation & Problem

Two gait metrics present in HealthKit are not currently supported by HealthKitOnFHIR:

- [Walking Asymmetry Percentage](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/3552086-walkingasymmetrypercentage)
- [Apple Walking Steadiness](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/3747016-applewalkingsteadiness)

## :gear: Release Notes 
Adds support for the above HK quantity types.

## :books: Documentation
Updates the documentation to reflect the new types.

## :white_check_mark: Testing
Adds a test for each new type.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
