### PR TITLE
Add mapping for HKQuantityTypeIdentifierWalkingSpeed

### DIFF
--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -2105,6 +2105,21 @@
                 "system": "http://unitsofmeasure.org",
                 "unit": "beats/minute"
             }
+        },
+        "HKQuantityTypeIdentifierWalkingSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierWalkingSpeed",
+                    "display": "Walking Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m.s-1",
+                "hkunit": "m/s",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m/s"
+            }
         }
     }
 }


### PR DESCRIPTION
# Add mapping for HKQuantityTypeIdentifierWalkingSpeed

## :recycle: Current situation & Problem
The HealthKitOnFHIR library currently does not have a mapping for [HKQuantityTypeIdentifierWalkingSpeed](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierwalkingspeed), a quantity that represents the average speed of walking between the start and end timestamps.


## :gear: Release Notes 
Adds a mapping for `HKQuantityTypeIdentifierWalkingSpeed`. As LOINC codes for walking speed also include a fixed time duration over which the average is taken (e.g. 24 hours), and this quantity does not have a fixed time period, this quantity cannot be precisely mapped to a LOINC code.

## :books: Documentation
The mapping file has been updated and documentation will be generated automatically.


## :white_check_mark: Testing
A unit test has been added.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
