### PR TITLE
Fixed missing swiftlint package dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMajor(from: "0.4.0"))
-    ],
+    ] + swiftLintPackage(),
     targets: [
         .target(
             name: "HealthKitOnFHIR",

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -56,7 +56,10 @@ class TestAppUITests: XCTestCase {
         app.launch()
         
         try exitAppAndOpenHealth(.electrocardiograms)
-        
+
+        app.launch()
+        XCTAssert(app.wait(for: .runningForeground, timeout: 6.0))
+
         XCTAssert(app.staticTexts["Electrocardiogram"].waitForExistence(timeout: 5))
         app.staticTexts["Electrocardiogram"].tap()
         XCTAssert(app.buttons["Read Electrocardiogram"].waitForExistence(timeout: 5))


### PR DESCRIPTION
# Fixed missing swiftlint package dependency

## :recycle: Current situation & Problem
The Package manifest was missing adding swiftlint as a package dependency. This resulted in failing to load the package if one enabled the `SPEZI_DEVELOPMENT_SWIFTLINT` environment variable.


## :gear: Release Notes 
* Fixed missing swiftlint package dependency.


## :books: Documentation
--


## :white_check_mark: Testing
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
