### PR TITLE
Add mapping for Time In Daylight

### DIFF
--- a/Scripts/support_table_generator.py
+++ b/Scripts/support_table_generator.py
@@ -101,6 +101,7 @@ ALL_QUANTITY_TYPES = [
     "HKQuantityTypeIdentifierRestingHeartRate",
     "HKQuantityTypeIdentifierStepCount",
     "HKQuantityTypeIdentifierSwimmingStrokeCount",
+    "HKQuantityTypeIdentifierTimeInDaylight",
     "HKQuantityTypeIdentifierUVExposure",
     "HKQuantityTypeIdentifierVO2Max",
     "HKQuantityTypeIdentifierWaistCircumference",

--- a/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HKSampleSupportTables.md
+++ b/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HKSampleSupportTables.md
@@ -17,5 +17,5 @@ SPDX-License-Identifier: MIT
 - [HKClinicalType](<doc:SupportedHKClinicalTypes>)
     - HealthKitOnFHIR supports 8 of 8 clinical types.
 - [HKQuantityType](<doc:SupportedHKQuantityTypes>)
-    - HealthKitOnFHIR supports 86 of 88 quantity types.
+    - HealthKitOnFHIR supports 87 of 89 quantity types.
     

--- a/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/SupportedHKQuantityTypes.md
+++ b/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/SupportedHKQuantityTypes.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
              
 -->
 
-HealthKitOnFHIR supports 86 of 88 quantity types.
+HealthKitOnFHIR supports 87 of 89 quantity types.
 
 |HKQuantityType|Supported|Code|Unit|
 |----|----|----|----|
@@ -95,6 +95,7 @@ HealthKitOnFHIR supports 86 of 88 quantity types.
 |[RestingHeartRate](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierRestingHeartRate)|✅|[40443-4](http://loinc.org/40443-4)|[beats/minute](http://unitsofmeasure.org)|
 |[StepCount](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierStepCount)|✅|[55423-8](http://loinc.org/55423-8)|steps|
 |[SwimmingStrokeCount](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierSwimmingStrokeCount)|✅|[HKQuantityTypeIdentifierSwimmingStrokeCount](http://developer.apple.com/documentation/healthkit)|strokes|
+|[TimeInDaylight](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierTimeInDaylight)|✅|[HKQuantityTypeIdentifierTimeInDaylight](http://developer.apple.com/documentation/healthkit)|[min](http://unitsofmeasure.org)|
 |[UVExposure](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierUVExposure)|✅|[HKQuantityTypeIdentifierUVExposure](http://developer.apple.com/documentation/healthkit)|count|
 |[VO2Max](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierVO2Max)|✅|[HKQuantityTypeIdentifierVO2Max](http://developer.apple.com/documentation/healthkit)|[mL/kg/min](http://unitsofmeasure.org)|
 |[WaistCircumference](https://developer.apple.com/documentation/healthkit/HKQuantityTypeIdentifierWaistCircumference)|✅|[8280-0](http://loinc.org/8280-0)|[in](http://unitsofmeasure.org)|

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -2029,6 +2029,21 @@
                 "unit": "strokes"
             }
         },
+        "HKQuantityTypeIdentifierTimeInDaylight": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierTimeInDaylight",
+                    "display": "Time in Daylight",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "min",
+                "hkunit": "min",
+                "system": "http://unitsofmeasure.org",
+                "unit": "min"
+            }
+        },
         "HKQuantityTypeIdentifierUVExposure": {
             "codings": [
                 {

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -1764,6 +1764,37 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
+    @available(iOS 17.0, *)
+    func testTimeInDaylight() throws {
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.timeInDaylight),
+            quantity: HKQuantity(unit: .minute(), doubleValue: 100)
+        )
+            
+        XCTAssertEqual(
+            observation.code.coding,
+            [
+                createCoding(
+                    code: "HKQuantityTypeIdentifierTimeInDaylight",
+                    display: "Time in Daylight",
+                    system: .apple
+                )
+            ]
+        )
+            
+        XCTAssertEqual(
+            observation.value,
+            .quantity(
+                Quantity(
+                    code: "min",
+                    system: "http://unitsofmeasure.org",
+                    unit: "min",
+                    value: 100.asFHIRDecimalPrimitive()
+                )
+            )
+        )
+    }
+    
     func testUVExposure() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.uvExposure),


### PR DESCRIPTION
# Add mapping for Time In Daylight

## :recycle: Current situation & Problem
Since iOS 17, HealthKit has added a [Time in Daylight quantity type](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/4168154-timeindaylight).


## :gear: Release Notes 
Adds a mapping for Time in Daylight to a FHIR Observation.


## :books: Documentation
Documentation script is updated and new documentation has been generated.


## :white_check_mark: Testing
Unit test added.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
