### PR TITLE
Set time zone from HK metadata in FHIR resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ HealthKitOnFHIR supports:
 
 Please refer to the [HKObject Support Table](Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HKSampleSupportTables.md) for a complete list of supported types.
 
+> [!NOTE] 
+> HealthKitOnFHIR will use the time zone specified in [HKMetadataKeyTimeZone](https://developer.apple.com/documentation/healthkit/hkmetadatakeytimezone) when creating FHIR resources from HealthKit samples. If no time zone is specified, HealthKitOnFHIR will use the device's current time zone.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ HealthKitOnFHIR supports:
 Please refer to the [HKObject Support Table](Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HKSampleSupportTables.md) for a complete list of supported types.
 
 > [!NOTE] 
-> HealthKitOnFHIR will use the time zone specified in [HKMetadataKeyTimeZone](https://developer.apple.com/documentation/healthkit/hkmetadatakeytimezone) when creating FHIR resources from HealthKit samples. If no time zone is specified, HealthKitOnFHIR will use the device's current time zone.
+> HealthKitOnFHIR will use the time zone specified in [HKMetadataKeyTimeZone](https://developer.apple.com/documentation/healthkit/hkmetadatakeytimezone) when creating FHIR Observations from HealthKit samples. If no time zone is specified, HealthKitOnFHIR will use the device's current time zone.
 
 ## Installation
 

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -33,7 +33,11 @@ extension HKSample {
         // Set basic elements applicable to all observations
         observation.id = self.uuid.uuidString.asFHIRStringPrimitive()
         observation.appendIdentifier(Identifier(id: observation.id))
-        observation.setEffective(startDate: self.startDate, endDate: self.endDate)
+        observation.setEffective(
+            startDate: self.startDate,
+            endDate: self.endDate,
+            timeZone: self.timeZone ?? .current
+        )
         observation.setIssued(on: Date())
         
         // Set specific data based on HealthKit type

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+TimeZone.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+TimeZone.swift
@@ -12,7 +12,7 @@ import HealthKit
 extension HKSample {
     /// Gets the `TimeZone` from the sample's metadata if available
     /// - Returns: A `TimeZone` if the metadata contains a valid HKMetadataKeyTimeZone value, otherwise nil
-    public var timeZone: TimeZone? {
+    internal var timeZone: TimeZone? {
         guard let timeZoneIdentifier = metadata?[HKMetadataKeyTimeZone] as? String else {
             return nil
         }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+TimeZone.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+TimeZone.swift
@@ -1,0 +1,21 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+
+
+extension HKSample {
+    /// Gets the `TimeZone` from the sample's metadata if available
+    /// - Returns: A `TimeZone` if the metadata contains a valid HKMetadataKeyTimeZone value, otherwise nil
+    public var timeZone: TimeZone? {
+        guard let timeZoneIdentifier = metadata?[HKMetadataKeyTimeZone] as? String else {
+            return nil
+        }
+        return TimeZone(identifier: timeZoneIdentifier)
+    }
+}

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
@@ -13,20 +13,21 @@ import ModelsR4
 
 extension Observation {
     func setEffective(startDate: Date, endDate: Date, timeZone: TimeZone) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = timeZone
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        
         if startDate == endDate {
             effective = .dateTime(
                 FHIRPrimitive(
-                    try? DateTime(
-                        date: startDate,
-                        timeZone: timeZone
-                    )
+                    try? DateTime(dateFormatter.string(from: startDate))
                 )
             )
         } else {
             effective = .period(
                 Period(
-                    end: FHIRPrimitive(try? DateTime(date: endDate, timeZone: timeZone)),
-                    start: FHIRPrimitive(try? DateTime(date: startDate, timeZone: timeZone))
+                    end: FHIRPrimitive(try? DateTime(dateFormatter.string(from: endDate))),
+                    start: FHIRPrimitive(try? DateTime(dateFormatter.string(from: startDate)))
                 )
             )
         }

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
@@ -12,14 +12,21 @@ import ModelsR4
 
 
 extension Observation {
-    func setEffective(startDate: Date, endDate: Date) {
+    func setEffective(startDate: Date, endDate: Date, timeZone: TimeZone) {
         if startDate == endDate {
-            effective = .dateTime(FHIRPrimitive(try? DateTime(date: startDate)))
+            effective = .dateTime(
+                FHIRPrimitive(
+                    try? DateTime(
+                        date: startDate,
+                        timeZone: timeZone
+                    )
+                )
+            )
         } else {
             effective = .period(
                 Period(
-                    end: FHIRPrimitive(try? DateTime(date: endDate)),
-                    start: FHIRPrimitive(try? DateTime(date: startDate))
+                    end: FHIRPrimitive(try? DateTime(date: endDate, timeZone: timeZone)),
+                    start: FHIRPrimitive(try? DateTime(date: startDate, timeZone: timeZone))
                 )
             )
         }

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -25,8 +25,8 @@ class TimeZoneTests: XCTestCase {
     }
     
     func createDatesFor(timeZone: String) throws -> (start: Date, end: Date) {
-        let startComponents = DateComponents(year: 2024, month: 3, day: 15, hour: 9, minute: 30, second: 0)
-        let endComponents = DateComponents(year: 2024, month: 3, day: 15, hour: 10, minute: 45, second: 0)
+        let startComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 9, minute: 00, second: 0)
+        let endComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 10, minute: 45, second: 0)
         
         return (
             try getTimeZoneDate(startComponents, timeZoneName: timeZone),
@@ -74,12 +74,12 @@ class TimeZoneTests: XCTestCase {
         
         XCTAssertEqual(
             startTimestamp,
-            "2024-03-15T09:30:00-08:00",
+            "2024-12-01T09:00:00-08:00",
             "Start timestamp should match expected format with timezone"
         )
         XCTAssertEqual(
             endTimestamp,
-            "2024-03-15T10:45:00-08:00",
+            "2024-12-01T10:45:00-08:00",
             "End timestamp should match expected format with timezone"
         )
     }
@@ -107,12 +107,12 @@ class TimeZoneTests: XCTestCase {
 
         XCTAssertEqual(
             startTimestamp,
-            "2024-03-15T09:30:00-05:00",
+            "2024-12-01T09:00:00-05:00",
             "Start timestamp should match expected format with timezone"
         )
         XCTAssertEqual(
             endTimestamp,
-            "2024-03-15T10:45:00-05:00",
+            "2024-12-01T10:45:00-05:00",
             "End timestamp should match expected format with timezone"
         )
     }
@@ -140,12 +140,12 @@ class TimeZoneTests: XCTestCase {
         
         XCTAssertEqual(
             startTimestamp,
-            "2024-03-15T09:30:00+05:30",
+            "2024-12-01T09:00:00+05:30",
             "Start timestamp should match expected format with timezone"
         )
         XCTAssertEqual(
             endTimestamp,
-            "2024-03-15T10:45:00+05:30",
+            "2024-12-01T10:45:00+05:30",
             "End timestamp should match expected format with timezone"
         )
     }
@@ -178,9 +178,11 @@ class TimeZoneTests: XCTestCase {
         let endTimestamp = try XCTUnwrap(period.end?.value?.description)
         
         let currentTimeZone = TimeZone.current
-        let expectedOffset = currentTimeZone.secondsFromGMT() / 3600
-        let sign = expectedOffset >= 0 ? "+" : "-"
-        let expectedOffsetString = String(format: "%@%02d:00", sign, abs(expectedOffset))
+        let totalMinutes = currentTimeZone.secondsFromGMT() / 60
+        let hours = abs(totalMinutes / 60)
+        let minutes = abs(totalMinutes % 60)
+        let sign = totalMinutes >= 0 ? "+" : "-"
+        let expectedOffsetString = String(format: "%@%02d:%02d", sign, hours, minutes)
         
         XCTAssertTrue(
             startTimestamp.contains(expectedOffsetString),

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -12,7 +12,7 @@ import ModelsR4
 import XCTest
 
 
-class TimeZoneTests: XCTestCase {
+class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
     func createDateInTimeZone(_ components: DateComponents, timeZone: TimeZone) throws -> Date {
         var calendar = Calendar.current
         calendar.timeZone = timeZone
@@ -62,7 +62,7 @@ class TimeZoneTests: XCTestCase {
     }
     
     
-    /// Tests specifying the pacific standard time zone (-08:00) in metadata with a different start and end date
+    /// Tests specifying the pacific standard time zone (-08:00) in metadata with a different start and end date (results in a FHIR `Period`)
     func testPSTTimeZonePeriod() throws {
         let timeZone = "America/Los_Angeles"
         let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
@@ -95,10 +95,10 @@ class TimeZoneTests: XCTestCase {
         )
     }
 
-    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date
+    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date (results in a FHIR `DateTime`)
     func testPSTTimeZoneDateTime() throws {
         let timeZone = "America/Los_Angeles"
-        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        let (startDate, _) = try createDatesFor(timeZone: timeZone)
         
         let observation = try createObservationFrom(
             type: HKQuantityType(.stepCount),
@@ -122,7 +122,7 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with a different start and end date
+    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with a different start and end date (results in a FHIR `Period`)
     func testPSTTimeZoneWithDSTPeriod() throws {
         let timeZone = "America/Los_Angeles"
         let (startDate, endDate) = try createDSTDatesFor(timeZone: timeZone)
@@ -155,10 +155,10 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date
+    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date  (results in a FHIR `DateTime`)
     func testPSTTimeZoneWithDSTDateTime() throws {
         let timeZone = "America/Los_Angeles"
-        let (startDate, endDate) = try createDSTDatesFor(timeZone: timeZone)
+        let (startDate, _) = try createDSTDatesFor(timeZone: timeZone)
         
         let observation = try createObservationFrom(
             type: HKQuantityType(.stepCount),
@@ -182,7 +182,7 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying eastern standard time (-5:00) in metadata with an HKSample that defines a period with a different start and end date
+    /// Tests specifying eastern standard time (-5:00) in metadata with an HKSample that defines a period with a different start and end date (results in a FHIR `Period`)
     func testESTTimeZonePeriod() throws {
         let timeZone = "America/New_York"
         let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
@@ -215,10 +215,10 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying eastern standard time (-5:00) in metadata with the same start and end date
+    /// Tests specifying eastern standard time (-5:00) in metadata with the same start and end date (results in a FHIR `DateTime`)
     func testESTTimeZoneDateTime() throws {
         let timeZone = "America/New_York"
-        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        let (startDate, _) = try createDatesFor(timeZone: timeZone)
         
         let observation = try createObservationFrom(
             type: HKQuantityType(.stepCount),
@@ -242,7 +242,7 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying indian standard time (+5:30) in metadata with a different start and end date
+    /// Tests specifying indian standard time (+5:30) in metadata with a different start and end date (results in a FHIR `Period`)
     func testISTTimeZonePeriod() throws {
         let timeZone = "Asia/Calcutta"
         let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
@@ -275,10 +275,10 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying indian standard time (+5:30) in metadata with the same start and end date
+    /// Tests specifying indian standard time (+5:30) in metadata with the same start and end date  (results in a FHIR `DateTime`)
     func testISTTimeZoneDateTime() throws {
         let timeZone = "Asia/Calcutta"
-        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        let (startDate, _) = try createDatesFor(timeZone: timeZone)
         
         let observation = try createObservationFrom(
             type: HKQuantityType(.stepCount),
@@ -302,7 +302,7 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests that the current time zone is added if a time zone is not specified in metadata with a different start and end date
+    /// Tests that the current time zone is added if a time zone is not specified in metadata with a different start and end date (results in a FHIR `Period`)
     func testDefaultTimeZonePeriod() throws {
         let startDate: Date = try {
             let dateComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 9, minute: 00, second: 0)
@@ -346,7 +346,7 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests that the current time zone is added if a time zone is not specified in metadata with the same start and end date
+    /// Tests that the current time zone is added if a time zone is not specified in metadata with the same start and end date  (results in a FHIR `DateTime`)
     func testDefaultTimeZoneDateTime() throws {
         let startDate: Date = try {
             let dateComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 9, minute: 00, second: 0)

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -337,6 +337,15 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
         let expectedOffsetString = String(format: "%@%02d:%02d", sign, hours, minutes)
         
         XCTAssertTrue(
+            startTimestamp.starts(with: "2024-12-01T09:00:00"),
+            "Start timestamp should begin with correct date and time"
+        )
+        XCTAssertTrue(
+            endTimestamp.starts(with: "2024-12-01T10:45:00"),
+            "End timestamp should begin with correct date and time"
+        )
+        
+        XCTAssertTrue(
             startTimestamp.contains(expectedOffsetString),
             "Start time should contain current timezone offset \(expectedOffsetString)"
         )
@@ -375,6 +384,11 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
         let minutes = abs(totalMinutes % 60)
         let sign = totalMinutes >= 0 ? "+" : "-"
         let expectedOffsetString = String(format: "%@%02d:%02d", sign, hours, minutes)
+        
+        XCTAssertTrue(
+            timestamp.starts(with: "2024-12-01T09:00:00"),
+            "Timestamp should begin with correct date and time"
+        )
         
         XCTAssertTrue(
             timestamp.contains(expectedOffsetString),

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -1,0 +1,194 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+@testable import HealthKitOnFHIR
+import ModelsR4
+import XCTest
+
+
+class TimeZoneTests: XCTestCase {
+    func createDateInTimeZone(_ components: DateComponents, timeZone: TimeZone) throws -> Date {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        return try XCTUnwrap(calendar.date(from: components))
+    }
+    
+    func getTimeZoneDate(_ components: DateComponents, timeZoneName: String) throws -> Date {
+        let timeZone = try XCTUnwrap(TimeZone(identifier: timeZoneName))
+        return try createDateInTimeZone(components, timeZone: timeZone)
+    }
+    
+    func createDatesFor(timeZone: String) throws -> (start: Date, end: Date) {
+        let startComponents = DateComponents(year: 2024, month: 3, day: 15, hour: 9, minute: 30, second: 0)
+        let endComponents = DateComponents(year: 2024, month: 3, day: 15, hour: 10, minute: 45, second: 0)
+        
+        return (
+            try getTimeZoneDate(startComponents, timeZoneName: timeZone),
+            try getTimeZoneDate(endComponents, timeZoneName: timeZone)
+        )
+    }
+    
+    func createObservationFrom(
+        type quantityType: HKQuantityType,
+        quantity: HKQuantity,
+        start: Date,
+        end: Date,
+        metadata: [String: Any] = [:]
+    ) throws -> Observation {
+        let quantitySample = HKQuantitySample(
+            type: quantityType,
+            quantity: quantity,
+            start: start,
+            end: end,
+            metadata: metadata
+        )
+        return try XCTUnwrap(quantitySample.resource.get(if: Observation.self))
+    }
+    
+    /// Tests specifying the pacific time zone (-08:00) in metadata
+    func testPSTTimeZone() throws {
+        let timeZone = "America/Los_Angeles"
+        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: endDate,
+            metadata: [HKMetadataKeyTimeZone: timeZone]
+        )
+        
+        guard case let .period(period) = observation.effective else {
+            XCTFail("Expected period effective type")
+            return
+        }
+        
+        let startTimestamp = try XCTUnwrap(period.start?.value?.description)
+        let endTimestamp = try XCTUnwrap(period.end?.value?.description)
+        
+        XCTAssertEqual(
+            startTimestamp,
+            "2024-03-15T09:30:00-08:00",
+            "Start timestamp should match expected format with timezone"
+        )
+        XCTAssertEqual(
+            endTimestamp,
+            "2024-03-15T10:45:00-08:00",
+            "End timestamp should match expected format with timezone"
+        )
+    }
+    
+    /// Tests specifying eastern standard time (-5:00) in metadata
+    func testESTTimeZone() throws {
+        let timeZone = "America/New_York"
+        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: endDate,
+            metadata: [HKMetadataKeyTimeZone: timeZone]
+        )
+        
+        guard case let .period(period) = observation.effective else {
+            XCTFail("Expected period effective type")
+            return
+        }
+        
+        let startTimestamp = try XCTUnwrap(period.start?.value?.description)
+        let endTimestamp = try XCTUnwrap(period.end?.value?.description)
+
+        XCTAssertEqual(
+            startTimestamp,
+            "2024-03-15T09:30:00-05:00",
+            "Start timestamp should match expected format with timezone"
+        )
+        XCTAssertEqual(
+            endTimestamp,
+            "2024-03-15T10:45:00-05:00",
+            "End timestamp should match expected format with timezone"
+        )
+    }
+    
+    /// Tests specifying indian standard time (+5:30) in metadata
+    func testISTTimeZone() throws {
+        let timeZone = "Asia/Calcutta"
+        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: endDate,
+            metadata: [HKMetadataKeyTimeZone: timeZone]
+        )
+        
+        guard case let .period(period) = observation.effective else {
+            XCTFail("Expected period effective type")
+            return
+        }
+        
+        let startTimestamp = try XCTUnwrap(period.start?.value?.description)
+        let endTimestamp = try XCTUnwrap(period.end?.value?.description)
+        
+        XCTAssertEqual(
+            startTimestamp,
+            "2024-03-15T09:30:00+05:30",
+            "Start timestamp should match expected format with timezone"
+        )
+        XCTAssertEqual(
+            endTimestamp,
+            "2024-03-15T10:45:00+05:30",
+            "End timestamp should match expected format with timezone"
+        )
+    }
+    
+    /// Tests that the current time zone is added if a time zone is not specified in metadata
+    func testDefaultTimeZone() throws {
+        let startDate: Date = try {
+            let dateComponents = DateComponents(year: 2024, month: 3, day: 15, hour: 9, minute: 30, second: 0)
+            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+        }()
+        
+        let endDate: Date = try {
+            let dateComponents = DateComponents(year: 2024, month: 3, day: 15, hour: 10, minute: 45, second: 0)
+            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+        }()
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: endDate
+        )
+        
+        guard case let .period(period) = observation.effective else {
+            XCTFail("Expected period effective type")
+            return
+        }
+        
+        let startTimestamp = try XCTUnwrap(period.start?.value?.description)
+        let endTimestamp = try XCTUnwrap(period.end?.value?.description)
+        
+        let currentTimeZone = TimeZone.current
+        let expectedOffset = currentTimeZone.secondsFromGMT() / 3600
+        let sign = expectedOffset >= 0 ? "+" : "-"
+        let expectedOffsetString = String(format: "%@%02d:00", sign, abs(expectedOffset))
+        
+        XCTAssertTrue(
+            startTimestamp.contains(expectedOffsetString),
+            "Start time should contain current timezone offset \(expectedOffsetString)"
+        )
+        XCTAssertTrue(
+            endTimestamp.contains(expectedOffsetString),
+            "End time should contain current timezone offset \(expectedOffsetString)"
+        )
+    }
+}

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -95,7 +95,7 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
         )
     }
 
-    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date (results in a FHIR `DateTime`)
+    /// Tests specifying the pacific standard time zone (-8:00) in metadata with the same start and end date (results in a FHIR `DateTime`)
     func testPSTTimeZoneDateTime() throws {
         let timeZone = "America/Los_Angeles"
         let (startDate, _) = try createDatesFor(timeZone: timeZone)
@@ -123,7 +123,7 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
     
     /// Tests specifying the pacific daylight time zone (-7:00) in metadata with a different start and end date (results in a FHIR `Period`)
-    func testPSTTimeZoneWithDSTPeriod() throws {
+    func testPDTTimeZonePeriod() throws {
         let timeZone = "America/Los_Angeles"
         let (startDate, endDate) = try createDSTDatesFor(timeZone: timeZone)
         
@@ -156,7 +156,7 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
     }
     
     /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date  (results in a FHIR `DateTime`)
-    func testPSTTimeZoneWithDSTDateTime() throws {
+    func testPDTTimeZoneDateTime() throws {
         let timeZone = "America/Los_Angeles"
         let (startDate, _) = try createDSTDatesFor(timeZone: timeZone)
         

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -61,8 +61,9 @@ class TimeZoneTests: XCTestCase {
         return try XCTUnwrap(quantitySample.resource.get(if: Observation.self))
     }
     
-    /// Tests specifying the pacific standard time zone (-08:00) in metadata
-    func testPSTTimeZone() throws {
+    
+    /// Tests specifying the pacific standard time zone (-08:00) in metadata with a different start and end date
+    func testPSTTimeZonePeriod() throws {
         let timeZone = "America/Los_Angeles"
         let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
         
@@ -93,9 +94,36 @@ class TimeZoneTests: XCTestCase {
             "End timestamp should match expected format with timezone"
         )
     }
+
+    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date
+    func testPSTTimeZoneDateTime() throws {
+        let timeZone = "America/Los_Angeles"
+        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: startDate,
+            metadata: [HKMetadataKeyTimeZone: timeZone]
+        )
+        
+        guard case let .dateTime(dateTime) = observation.effective else {
+            XCTFail("Expected dateTime effective type")
+            return
+        }
+        
+        let timestamp = try XCTUnwrap(dateTime.value?.description)
+        
+        XCTAssertEqual(
+            timestamp,
+            "2024-12-01T09:00:00-08:00",
+            "Timestamp should match expected format with timezone"
+        )
+    }
     
-    /// Tests specifying the pacific daylight time zone (-7:00) in metadata
-    func testPSTTimeZoneWithDST() throws {
+    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with a different start and end date
+    func testPSTTimeZoneWithDSTPeriod() throws {
         let timeZone = "America/Los_Angeles"
         let (startDate, endDate) = try createDSTDatesFor(timeZone: timeZone)
         
@@ -127,8 +155,35 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying eastern standard time (-5:00) in metadata
-    func testESTTimeZone() throws {
+    /// Tests specifying the pacific daylight time zone (-7:00) in metadata with the same start and end date
+    func testPSTTimeZoneWithDSTDateTime() throws {
+        let timeZone = "America/Los_Angeles"
+        let (startDate, endDate) = try createDSTDatesFor(timeZone: timeZone)
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: startDate,
+            metadata: [HKMetadataKeyTimeZone: timeZone]
+        )
+        
+        guard case let .dateTime(dateTime) = observation.effective else {
+            XCTFail("Expected dateTime effective type")
+            return
+        }
+        
+        let timestamp = try XCTUnwrap(dateTime.value?.description)
+        
+        XCTAssertEqual(
+            timestamp,
+            "2024-04-01T09:00:00-07:00",
+            "Timestamp should match expected format with timezone during DST"
+        )
+    }
+    
+    /// Tests specifying eastern standard time (-5:00) in metadata with an HKSample that defines a period with a different start and end date
+    func testESTTimeZonePeriod() throws {
         let timeZone = "America/New_York"
         let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
         
@@ -160,8 +215,35 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests specifying indian standard time (+5:30) in metadata
-    func testISTTimeZone() throws {
+    /// Tests specifying eastern standard time (-5:00) in metadata with the same start and end date
+    func testESTTimeZoneDateTime() throws {
+        let timeZone = "America/New_York"
+        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: startDate,
+            metadata: [HKMetadataKeyTimeZone: timeZone]
+        )
+        
+        guard case let .dateTime(dateTime) = observation.effective else {
+            XCTFail("Expected dateTime effective type")
+            return
+        }
+        
+        let timestamp = try XCTUnwrap(dateTime.value?.description)
+        
+        XCTAssertEqual(
+            timestamp,
+            "2024-12-01T09:00:00-05:00",
+            "Timestamp should match expected format with timezone"
+        )
+    }
+    
+    /// Tests specifying indian standard time (+5:30) in metadata with a different start and end date
+    func testISTTimeZonePeriod() throws {
         let timeZone = "Asia/Calcutta"
         let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
         
@@ -193,8 +275,35 @@ class TimeZoneTests: XCTestCase {
         )
     }
     
-    /// Tests that the current time zone is added if a time zone is not specified in metadata
-    func testDefaultTimeZone() throws {
+    /// Tests specifying indian standard time (+5:30) in metadata with the same start and end date
+    func testISTTimeZoneDateTime() throws {
+        let timeZone = "Asia/Calcutta"
+        let (startDate, endDate) = try createDatesFor(timeZone: timeZone)
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: startDate,
+            metadata: [HKMetadataKeyTimeZone: timeZone]
+        )
+        
+        guard case let .dateTime(dateTime) = observation.effective else {
+            XCTFail("Expected dateTime effective type")
+            return
+        }
+        
+        let timestamp = try XCTUnwrap(dateTime.value?.description)
+        
+        XCTAssertEqual(
+            timestamp,
+            "2024-12-01T09:00:00+05:30",
+            "Timestamp should match expected format with timezone"
+        )
+    }
+    
+    /// Tests that the current time zone is added if a time zone is not specified in metadata with a different start and end date
+    func testDefaultTimeZonePeriod() throws {
         let startDate: Date = try {
             let dateComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 9, minute: 00, second: 0)
             return try XCTUnwrap(Calendar.current.date(from: dateComponents))
@@ -234,6 +343,42 @@ class TimeZoneTests: XCTestCase {
         XCTAssertTrue(
             endTimestamp.contains(expectedOffsetString),
             "End time should contain current timezone offset \(expectedOffsetString)"
+        )
+    }
+    
+    /// Tests that the current time zone is added if a time zone is not specified in metadata with the same start and end date
+    func testDefaultTimeZoneDateTime() throws {
+        let startDate: Date = try {
+            let dateComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 9, minute: 00, second: 0)
+            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+        }()
+        
+        let endDate = startDate
+        
+        let observation = try createObservationFrom(
+            type: HKQuantityType(.stepCount),
+            quantity: HKQuantity(unit: .count(), doubleValue: 42),
+            start: startDate,
+            end: endDate
+        )
+        
+        guard case let .dateTime(dateTime) = observation.effective else {
+            XCTFail("Expected dateTime effective type")
+            return
+        }
+        
+        let timestamp = try XCTUnwrap(dateTime.value?.description)
+        
+        let currentTimeZone = TimeZone.current
+        let totalMinutes = currentTimeZone.secondsFromGMT() / 60
+        let hours = abs(totalMinutes / 60)
+        let minutes = abs(totalMinutes % 60)
+        let sign = totalMinutes >= 0 ? "+" : "-"
+        let expectedOffsetString = String(format: "%@%02d:%02d", sign, hours, minutes)
+        
+        XCTAssertTrue(
+            timestamp.contains(expectedOffsetString),
+            "Time should contain current timezone offset \(expectedOffsetString)"
         )
     }
 }


### PR DESCRIPTION
# Set time zone from HK metadata in FHIR resources

## :recycle: Current situation & Problem
The HealthKitOnFHIR library currently assumes that HealthKit samples were created in the current time zone of the device at the time of mapping and applies the corresponding UTC offset. While this is true for most situations, it is possible that older HealthKit data may be mapped using the library that was created while the user was in a different time zone. 

For example, if a sample was originally created by HealthKit in San Francisco on December 1st, 2024 at 9:00am (-08:00), but then mapped by HealthKitOnFHIR later on in New York, the timestamp would read 2024-12-01T12:00:00-05:00. While technically these are the same point in time, they are offset differently.

The information regarding the original timezone of the sample may be stored by HealthKit in the object's metadata via [HKMetadataKeyTimeZone](https://developer.apple.com/documentation/healthkit/hkmetadatakeytimezone), if this was written by the original application or device that created the data, and we should use it to apply the appropriate offset.


## :gear: Release Notes 
- If a time zone has been defined in [HKMetadataKeyTimeZone](https://developer.apple.com/documentation/healthkit/hkmetadatakeytimezone), it is set when serializing HealthKit samples.

## :white_check_mark: Testing
Unit tests have been updated to test that the appropriate offset is applied for multiple time zones specified via metadata and test that the offset of the current time zone is applied if none is specified.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
