### PR TITLE
explicit watchOS support, Swift 6, existential any

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,23 +16,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  buildandtest:
-    name: Build and Test Swift Package
+  buildandtest_ios:
+    name: Build and Test Swift Package iOS
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: HealthKitOnFHIR
-      artifactname: HealthKitOnFHIR.xcresult
-  buildandtestlatest:
-    name: Build and Test Swift Package Latest
+      resultBundle: HealthKitOnFHIR-iOS.xcresult
+      artifactname: HealthKitOnFHIR-iOS.xcresult
+  buildandtest_macos:
+    name: Build and Test Swift Package macOS
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: HealthKitOnFHIR
-      xcodeversion: latest
-      swiftVersion: 6
-      resultBundle: HealthKitOnFHIRLatest.xcresult
-      artifactname: HealthKitOnFHIRLatest.xcresult
+      destination: 'platform=macOS,arch=arm64'
+      resultBundle: HealthKitOnFHIR-macOS.xcresult
+      artifactname: HealthKitOnFHIR-macOS.xcresult
+  buildandtest_watchos:
+    name: Build and Test Swift Package watchOS
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'
+      scheme: HealthKitOnFHIR
+      destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
+      resultBundle: HealthKitOnFHIR-watchOS.xcresult
+      artifactname: HealthKitOnFHIR-watchOS.xcresult
   buildandtestuitests:
     name: Build and Test UI Tests
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
@@ -43,9 +52,9 @@ jobs:
       artifactname: TestApp.xcresult
   uploadcoveragereport:
     name: Upload Coverage Report
-    needs: [buildandtest, buildandtestuitests]
+    needs: [buildandtest_ios, buildandtest_macos, buildandtest_watchos, buildandtestuitests]
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
-      coveragereports: HealthKitOnFHIR.xcresult TestApp.xcresult
+      coveragereports: HealthKitOnFHIR-iOS.xcresult HealthKitOnFHIR-macOS.xcresult HealthKitOnFHIR-watchOS.xcresult TestApp.xcresult
     secrets:
       token: ${{ secrets.CODECOV_TOKEN }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 
 //
 // This source file is part of the HealthKitOnFHIR open source project
@@ -10,13 +10,6 @@
 
 import class Foundation.ProcessInfo
 import PackageDescription
-
-
-#if swift(<6)
-let swiftConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
-#else
-let swiftConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
-#endif
 
 
 let package = Package(
@@ -42,9 +35,7 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -52,9 +43,7 @@ let package = Package(
             dependencies: [
                 .target(name: "HealthKitOnFHIR")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,9 @@ let package = Package(
     name: "HealthKitOnFHIR",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v16)
+        .iOS(.v16),
+        .macOS(.v13),
+        .watchOS(.v9)
     ],
     products: [
         .library(name: "HealthKitOnFHIR", targets: ["HealthKitOnFHIR"])

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/HKSampleMapping.swift
@@ -40,7 +40,7 @@ public struct HKSampleMapping: Decodable, Sendable {
     public var workoutSampleMapping: HKWorkoutSampleMapping
 
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let mappings = try decoder.container(keyedBy: CodingKeys.self)
         let quantityStringBasedSampleMapping = try mappings.decode(
             [String: HKQuantitySampleMapping].self,

--- a/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
+++ b/Sources/HealthKitOnFHIR/HKSampleMapping/MappedUnit.swift
@@ -29,7 +29,7 @@ public struct MappedUnit: Decodable, Sendable {
     public private(set) var code: String?
     
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         let hkunit = try HKUnit(from: values.decode(String.self, forKey: .hkunit))
         let unit = try values.decode(String.self, forKey: .unit)

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
@@ -24,6 +24,7 @@ extension HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueCervicalMucusQuality: @retroactive CustomStringConvertible {}
 extension HKCategoryValueCervicalMucusQuality: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -45,6 +46,7 @@ extension HKCategoryValueCervicalMucusQuality: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueMenstrualFlow: @retroactive CustomStringConvertible {}
 extension HKCategoryValueMenstrualFlow: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -66,6 +68,7 @@ extension HKCategoryValueMenstrualFlow: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueOvulationTestResult: @retroactive CustomStringConvertible {}
 extension HKCategoryValueOvulationTestResult: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -85,6 +88,7 @@ extension HKCategoryValueOvulationTestResult: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueContraceptive: @retroactive CustomStringConvertible {}
 extension HKCategoryValueContraceptive: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -110,6 +114,7 @@ extension HKCategoryValueContraceptive: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueSleepAnalysis: @retroactive CustomStringConvertible {}
 extension HKCategoryValueSleepAnalysis: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -133,6 +138,7 @@ extension HKCategoryValueSleepAnalysis: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueAppetiteChanges: @retroactive CustomStringConvertible {}
 extension HKCategoryValueAppetiteChanges: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -152,6 +158,7 @@ extension HKCategoryValueAppetiteChanges: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueEnvironmentalAudioExposureEvent: @retroactive CustomStringConvertible {}
 extension HKCategoryValueEnvironmentalAudioExposureEvent: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -165,6 +172,7 @@ extension HKCategoryValueEnvironmentalAudioExposureEvent: HKCategoryValueDescrip
     }
 }
 
+extension HKCategoryValueHeadphoneAudioExposureEvent: @retroactive CustomStringConvertible {}
 extension HKCategoryValueHeadphoneAudioExposureEvent: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -178,6 +186,7 @@ extension HKCategoryValueHeadphoneAudioExposureEvent: HKCategoryValueDescription
     }
 }
 
+extension HKCategoryValueLowCardioFitnessEvent: @retroactive CustomStringConvertible {}
 extension HKCategoryValueLowCardioFitnessEvent: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -191,6 +200,7 @@ extension HKCategoryValueLowCardioFitnessEvent: HKCategoryValueDescription {
     }
 }
 
+extension HKAppleWalkingSteadinessClassification: @retroactive CustomStringConvertible {}
 extension HKAppleWalkingSteadinessClassification: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -208,6 +218,7 @@ extension HKAppleWalkingSteadinessClassification: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueAppleWalkingSteadinessEvent: @retroactive CustomStringConvertible {}
 extension HKCategoryValueAppleWalkingSteadinessEvent: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -227,6 +238,7 @@ extension HKCategoryValueAppleWalkingSteadinessEvent: HKCategoryValueDescription
     }
 }
 
+extension HKCategoryValuePregnancyTestResult: @retroactive CustomStringConvertible {}
 extension HKCategoryValuePregnancyTestResult: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -244,6 +256,7 @@ extension HKCategoryValuePregnancyTestResult: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueProgesteroneTestResult: @retroactive CustomStringConvertible {}
 extension HKCategoryValueProgesteroneTestResult: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -261,6 +274,7 @@ extension HKCategoryValueProgesteroneTestResult: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueAppleStandHour: @retroactive CustomStringConvertible {}
 extension HKCategoryValueAppleStandHour: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -276,6 +290,7 @@ extension HKCategoryValueAppleStandHour: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValueSeverity: @retroactive CustomStringConvertible {}
 extension HKCategoryValueSeverity: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -297,6 +312,7 @@ extension HKCategoryValueSeverity: HKCategoryValueDescription {
     }
 }
 
+extension HKCategoryValuePresence: @retroactive CustomStringConvertible {}
 extension HKCategoryValuePresence: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKClinicalRecord+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKClinicalRecord+ResourceProxy.swift
@@ -10,6 +10,7 @@ import HealthKit
 import ModelsR4
 
 
+@available(watchOS, unavailable)
 extension HKClinicalRecord {
     /// Converts an `HKClinicalRecord` into a corresponding FHIR resource, encapsulated in a `ResourceProxy`
     func resource() throws -> ResourceProxy {

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
@@ -10,6 +10,7 @@ import HealthKit
 import ModelsR4
 
 
+extension HKElectrocardiogram.Classification: @retroactive CustomStringConvertible {}
 extension HKElectrocardiogram.Classification: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {
@@ -38,6 +39,7 @@ extension HKElectrocardiogram.Classification: HKCategoryValueDescription {
 }
 
 
+extension HKElectrocardiogram.SymptomsStatus: @retroactive CustomStringConvertible {}
 extension HKElectrocardiogram.SymptomsStatus: HKCategoryValueDescription {
     var categoryValueDescription: String {
         get throws {

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -50,8 +50,10 @@ extension HKSample {
             try categorySample.buildCategoryObservation(&observation)
         case let electrocardiogram as HKElectrocardiogram:
             try electrocardiogram.buildObservation(&observation, mappings: mapping)
+        #if !os(watchOS)
         case let clinicalRecord as HKClinicalRecord:
             return try clinicalRecord.resource()
+        #endif
         case let workout as HKWorkout:
             try workout.buildWorkoutObservation(&observation)
         default:

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKWorkoutActivityType+String.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKWorkoutActivityType+String.swift
@@ -24,6 +24,7 @@ extension HKWorkoutActivityTypeDescription {
     }
 }
 
+extension HKWorkoutActivityType: @retroactive CustomStringConvertible {}
 extension HKWorkoutActivityType: HKWorkoutActivityTypeDescription {
     var workoutTypeDescription: String {
         get throws {

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -1764,7 +1764,7 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
-    @available(iOS 17.0, *)
+    @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
     func testTimeInDaylight() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.timeInDaylight),
@@ -2379,7 +2379,7 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
-    @available(iOS 17.0, *)
+    @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
     func testApplePhysicalEffort() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.physicalEffort),

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -330,7 +330,7 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
         let endTimestamp = try XCTUnwrap(period.end?.value?.description)
         
         let currentTimeZone = TimeZone.current
-        let totalMinutes = currentTimeZone.secondsFromGMT() / 60
+        let totalMinutes = currentTimeZone.secondsFromGMT(for: startDate) / 60
         let hours = abs(totalMinutes / 60)
         let minutes = abs(totalMinutes % 60)
         let sign = totalMinutes >= 0 ? "+" : "-"
@@ -379,7 +379,7 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
         let timestamp = try XCTUnwrap(dateTime.value?.description)
         
         let currentTimeZone = TimeZone.current
-        let totalMinutes = currentTimeZone.secondsFromGMT() / 60
+        let totalMinutes = currentTimeZone.secondsFromGMT(for: startDate) / 60
         let hours = abs(totalMinutes / 60)
         let minutes = abs(totalMinutes % 60)
         let sign = totalMinutes >= 0 ? "+" : "-"

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -392,7 +392,7 @@ class TimeZoneTests: XCTestCase { // swiftlint:disable:this type_body_length
         
         XCTAssertTrue(
             timestamp.contains(expectedOffsetString),
-            "Time should contain current timezone offset \(expectedOffsetString)"
+            "Time should contain current timezone offset '\(expectedOffsetString)' (timestamp: '\(timestamp)')"
         )
     }
 }

--- a/Tests/UITests/TestApp/HealthKitManager.swift
+++ b/Tests/UITests/TestApp/HealthKitManager.swift
@@ -9,15 +9,18 @@
 
 import Foundation
 import HealthKit
+import Observation
 
 
-class HealthKitManager: ObservableObject {
-    var healthStore: HKHealthStore?
-    
+@Observable
+final class HealthKitManager: Sendable {
+    let healthStore: HKHealthStore?
     
     init() {
         if HKHealthStore.isHealthDataAvailable() {
             healthStore = HKHealthStore()
+        } else {
+            healthStore = nil
         }
     }
     

--- a/Tests/UITests/TestApp/Views/CreateWorkoutView.swift
+++ b/Tests/UITests/TestApp/Views/CreateWorkoutView.swift
@@ -10,7 +10,7 @@ import HealthKit
 import SwiftUI
 
 struct CreateWorkoutView: View {
-    @StateObject private var manager = HealthKitManager()
+    @State private var manager = HealthKitManager()
 
     @State private var json = ""
     @State private var showingSheet = false

--- a/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
+++ b/Tests/UITests/TestApp/Views/ElectrocardiogramTestView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 
 
 struct ElectrocardiogramTestView: View {
-    @StateObject private var manager = HealthKitManager()
+    @State private var manager = HealthKitManager()
     
     @State private var observation: Observation?
     @State private var passed = false

--- a/Tests/UITests/TestApp/Views/HealthRecordsTestView.swift
+++ b/Tests/UITests/TestApp/Views/HealthRecordsTestView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 
 struct HealthRecordsTestView: View {
-    @StateObject private var manager = HealthKitManager()
+    @State private var manager = HealthKitManager()
     
     @State private var json = ""
     @State private var showingSheet = false

--- a/Tests/UITests/TestApp/Views/ReadDataView.swift
+++ b/Tests/UITests/TestApp/Views/ReadDataView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 
 struct ReadDataView: View {
-    @StateObject private var manager = HealthKitManager()
+    @State private var manager = HealthKitManager()
     
     @State private var json = ""
     @State private var showingSheet = false

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -439,7 +440,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
+				SWIFT_UPCOMING_FEATURE_EXISTENTIAL_ANY = YES;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -466,6 +468,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -475,7 +478,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
+				SWIFT_UPCOMING_FEATURE_EXISTENTIAL_ANY = YES;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
# explicit watchOS support, Swift 6, existential any

## :recycle: Current situation & Problem
- This PR adds explicit support for watchOS targets, with some new conditional availability handling for `HKClinicalRecord`, which isn't available on watchOS.
- This PR also updates the swift-tools-version to 6.0, and makes some corresponding changes (a bunch of protocol conformance extensions are now marked as `@retroactive`, to make explicit what previously was implicit behavior)
- The UITests application is also migrated to Swift 6
- The PR also adds the `ExistentialAny` swift flag.

Additionally, this PR fixes an issue with the time zone-related tests, which is probably only occurring right now since the US is currently in DST, while the UK (ie, GMT) hasn't yet switched over.


## :gear: Release Notes
- added support for watchOS and macOS
- updated to Swift 6


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
