### PR TITLE
vastly improve HKSample → ResourceProxy performance

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ HealthKitOnFHIR contributors
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
 * [Vishnu Ravi](https://github.com/vishnuravi)
+* [Lukas Kollmer](https://github.com/lukaskollmer)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The HealthKitOnFHIR library provides extensions that convert supported HealthKit
 
 ```swift
 let sample: HKSample = // ...
-let resource = try sample.resource
+let resource = try sample.resource()
 ```
 
 ### Observations
@@ -52,7 +52,7 @@ let resource = try sample.resource
 
 ```swift
 let sample: HKQuantitySample = // ...
-let observation = try sample.resource.get(if: Observation.self)
+let observation = try sample.resource().get(if: Observation.self)
 ```
 
 Codes and units can be customized by passing in a custom `HKSampleMapping` instance to the `resource(withMapping:)` method.
@@ -69,7 +69,7 @@ let observation = try sample.resource(withMapping: sampleMapping).get(if: Observ
 
 ```swift
 let allergyRecord: HKClinicalRecord = // ...
-let allergyIntolerance = try allergyRecord.resource.get(if: AllergyIntolerance.self)
+let allergyIntolerance = try allergyRecord.resource().get(if: AllergyIntolerance.self)
 ```
 
 
@@ -94,7 +94,7 @@ let sample = HKQuantitySample(
 // Convert the results to FHIR observations
 let observation: Observation?
 do {
-    try observation = sample.resource.get(if: Observation.self)
+    try observation = sample.resource().get(if: Observation.self)
 } catch {
     // Handle any mapping errors here.
     // ...

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -10,36 +10,61 @@ import HealthKit
 import ModelsR4
 
 
-extension HKSample {
+/// A type which can be turned into a FHIR `ResourceProxy`
+public protocol ResourceProxyProviding: HKSample {
+    /// A `ResourceProxy` containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
+    ///
+    /// - parameter mapping: A mapping to map `HKSample`s to corresponding FHIR observations allowing the customization of, e.g., codings and units. See ``HKSampleMapping``.
+    /// - parameter issuedDate: `Instant` specifying when this version of the resource was made available. Defaults to `Date.now`.
+    /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
+    /// - throws: If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
+    func resource(withMapping mapping: HKSampleMapping, issuedDate: FHIRPrimitive<Instant>?) throws -> ResourceProxy
+}
+
+
+extension ResourceProxyProviding {
+    /// A `ResourceProxy` containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
+    ///
+    /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
+    /// - throws: If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
+    public func resource() throws -> ResourceProxy {
+        try resource(withMapping: .default, issuedDate: nil)
+    }
+}
+
+
+extension HKSample: ResourceProxyProviding {
     /// Converts an `HKSample` into an FHIR  resource, encapsulated in a `ResourceProxy`
+    @available(
+        *, deprecated,
+         renamed: "resource()",
+         // swiftlint:disable:next line_length
+         message: "Important: When mapping an array of HKSample objects into ResourceProxies, for performance reasons always prefer 'Collection.mapIntoResourceProxies()' or 'Collection.compactMapIntoResourceProxies()'"
+    )
     public var resource: ResourceProxy {
         get throws {
             try resource()
         }
     }
     
-    
-    /// A `ResourceProxy` containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    ///
-    /// If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
-    /// - Parameter withMapping: A mapping to map `HKSample`s to corresponding FHIR observations allowing the customization of, e.g., codings and units. See ``HKSampleMapping``.
-    /// - Returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    public func resource(withMapping mapping: HKSampleMapping = HKSampleMapping.default) throws -> ResourceProxy {
+    public func resource(withMapping mapping: HKSampleMapping = .default, issuedDate: FHIRPrimitive<Instant>? = nil) throws -> ResourceProxy {
         var observation = Observation(
             code: CodeableConcept(),
             status: FHIRPrimitive(.final)
         )
-        
         // Set basic elements applicable to all observations
         observation.id = self.uuid.uuidString.asFHIRStringPrimitive()
         observation.appendIdentifier(Identifier(id: observation.id))
-        observation.setEffective(
+        try observation.setEffective(
             startDate: self.startDate,
             endDate: self.endDate,
             timeZone: self.timeZone ?? .current
         )
-        observation.setIssued(on: Date())
-        
+        if let issuedDate {
+            observation.issued = issuedDate
+        } else {
+            try observation.setIssued(on: Date())
+        }
         // Set specific data based on HealthKit type
         switch self {
         case let quantitySample as HKQuantitySample:
@@ -59,7 +84,25 @@ extension HKSample {
         default:
             throw HealthKitOnFHIRError.notSupported
         }
-        
         return ResourceProxy(with: observation)
+    }
+}
+
+
+extension Collection where Element: ResourceProxyProviding {
+    /// Produces an Array of FHIR `ResourceProxies`.
+    ///
+    /// - Note: This method provides significant performance improvements as compared to calling ``ResourceProxyProviding/resource()`` for each element in the collection.
+    public func mapIntoResourceProxies() throws -> [ResourceProxy] {
+        let issuedDate = FHIRPrimitive<Instant>(try Instant(date: .now))
+        return try map { try $0.resource(issuedDate: issuedDate) }
+    }
+    
+    /// Produces an Array of FHIR `ResourceProxies`.
+    ///
+    /// - Note: This method provides significant performance improvements as compared to calling ``ResourceProxyProviding/resource()`` for each element in the collection.
+    public func compactMapIntoResourceProxies() throws -> [ResourceProxy] {
+        let issuedDate = FHIRPrimitive<Instant>(try Instant(date: .now))
+        return compactMap { try? $0.resource(issuedDate: issuedDate) }
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -39,7 +39,7 @@ extension HKSample: ResourceProxyProviding {
         *, deprecated,
          renamed: "resource()",
          // swiftlint:disable:next line_length
-         message: "Important: When mapping an array of HKSample objects into ResourceProxies, for performance reasons always prefer 'Collection.mapIntoResourceProxies()' or 'Collection.compactMapIntoResourceProxies()'"
+         message: "Important: When mapping an array of HKSample objects into ResourceProxies, for performance reasons always prefer 'Sequence.mapIntoResourceProxies()' or 'Sequence.compactMapIntoResourceProxies()'"
     )
     public var resource: ResourceProxy {
         get throws {
@@ -89,7 +89,7 @@ extension HKSample: ResourceProxyProviding {
 }
 
 
-extension Collection where Element: ResourceProxyProviding {
+extension Sequence where Element: ResourceProxyProviding {
     /// Produces an Array of FHIR `ResourceProxies`.
     ///
     /// - Note: This method provides significant performance improvements as compared to calling ``ResourceProxyProviding/resource()`` for each element in the collection.

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -10,30 +10,7 @@ import HealthKit
 import ModelsR4
 
 
-/// A type which can be turned into a FHIR `ResourceProxy`
-public protocol ResourceProxyProviding: HKSample {
-    /// A `ResourceProxy` containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    ///
-    /// - parameter mapping: A mapping to map `HKSample`s to corresponding FHIR observations allowing the customization of, e.g., codings and units. See ``HKSampleMapping``.
-    /// - parameter issuedDate: `Instant` specifying when this version of the resource was made available. Defaults to `Date.now`.
-    /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    /// - throws: If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
-    func resource(withMapping mapping: HKSampleMapping, issuedDate: FHIRPrimitive<Instant>?) throws -> ResourceProxy
-}
-
-
-extension ResourceProxyProviding {
-    /// A `ResourceProxy` containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    ///
-    /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    /// - throws: If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
-    public func resource() throws -> ResourceProxy {
-        try resource(withMapping: .default, issuedDate: nil)
-    }
-}
-
-
-extension HKSample: ResourceProxyProviding {
+extension HKSample {
     /// Converts an `HKSample` into an FHIR  resource, encapsulated in a `ResourceProxy`
     @available(
         *, deprecated,
@@ -47,6 +24,13 @@ extension HKSample: ResourceProxyProviding {
         }
     }
     
+    
+    /// A `ResourceProxy` containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
+    ///
+    /// - parameter mapping: A mapping to map `HKSample`s to corresponding FHIR observations allowing the customization of, e.g., codings and units. See ``HKSampleMapping``.
+    /// - parameter issuedDate: `Instant` specifying when this version of the resource was made available. Defaults to `Date.now`.
+    /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
+    /// - throws: If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
     public func resource(withMapping mapping: HKSampleMapping = .default, issuedDate: FHIRPrimitive<Instant>? = nil) throws -> ResourceProxy {
         var observation = Observation(
             code: CodeableConcept(),
@@ -89,7 +73,7 @@ extension HKSample: ResourceProxyProviding {
 }
 
 
-extension Sequence where Element: ResourceProxyProviding {
+extension Sequence where Element: HKSample {
     /// Produces an Array of FHIR `ResourceProxies`.
     ///
     /// - Note: This method provides significant performance improvements as compared to calling ``ResourceProxyProviding/resource()`` for each element in the collection.

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -77,16 +77,16 @@ extension Sequence where Element: HKSample {
     /// Produces an Array of FHIR `ResourceProxies`.
     ///
     /// - Note: This method provides significant performance improvements as compared to calling ``ResourceProxyProviding/resource()`` for each element in the collection.
-    public func mapIntoResourceProxies() throws -> [ResourceProxy] {
+    public func mapIntoResourceProxies(using mapping: HKSampleMapping = .default) throws -> [ResourceProxy] {
         let issuedDate = FHIRPrimitive<Instant>(try Instant(date: .now))
-        return try map { try $0.resource(issuedDate: issuedDate) }
+        return try map { try $0.resource(withMapping: mapping, issuedDate: issuedDate) }
     }
     
     /// Produces an Array of FHIR `ResourceProxies`.
     ///
     /// - Note: This method provides significant performance improvements as compared to calling ``ResourceProxyProviding/resource()`` for each element in the collection.
-    public func compactMapIntoResourceProxies() throws -> [ResourceProxy] {
+    public func compactMapIntoResourceProxies(using mapping: HKSampleMapping = .default) throws -> [ResourceProxy] {
         let issuedDate = FHIRPrimitive<Instant>(try Instant(date: .now))
-        return compactMap { try? $0.resource(issuedDate: issuedDate) }
+        return compactMap { try? $0.resource(withMapping: mapping, issuedDate: issuedDate) }
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HealthKitOnFHIR.md
+++ b/Sources/HealthKitOnFHIR/HealthKitOnFHIR.docc/HealthKitOnFHIR.md
@@ -28,7 +28,7 @@ The HealthKitOnFHIR framework provides extensions that convert supported HealthK
 
 ```swift
 let sample: HKSample = // ...
-let resource = try sample.resource
+let resource = try sample.resource()
 ```
 
 ### Observations
@@ -37,7 +37,7 @@ let resource = try sample.resource
 
 ```swift
 let sample: HKQuantitySample = // ...
-let observation = try sample.resource.get(if: Observation.self)
+let observation = try sample.resource().get(if: Observation.self)
 ```
 
 Codes and units can be customized by passing in a custom `HKSampleMapping` instance to the `resource(withMapping:)` method.
@@ -54,7 +54,7 @@ let observation = try sample.resource(withMapping: sampleMapping).get(if: Observ
 
 ```swift
 let allergyRecord: HKClinicalRecord = // ...
-let allergyIntolerance = try allergyRecord.resource.get(if: AllergyIntolerance.self)
+let allergyIntolerance = try allergyRecord.resource().get(if: AllergyIntolerance.self)
 ```
 
 ## Example
@@ -78,7 +78,7 @@ let sample = HKQuantitySample(
 // Convert the results to FHIR observations
 let observation: Observation?
 do {
-    try observation = sample.resource.get(if: Observation.self)
+    try observation = sample.resource().get(if: Observation.self)
 } catch {
     // Handle any mapping errors here.
     // ...

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
@@ -12,28 +12,18 @@ import ModelsR4
 
 
 extension Observation {
-    func setEffective(startDate: Date, endDate: Date, timeZone: TimeZone) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeZone = timeZone
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-        
+    func setEffective(startDate: Date, endDate: Date, timeZone: TimeZone) throws {
         if startDate == endDate {
-            effective = .dateTime(
-                FHIRPrimitive(
-                    try? DateTime(dateFormatter.string(from: startDate))
-                )
-            )
+            effective = .dateTime(FHIRPrimitive(try DateTime(date: startDate, timeZone: timeZone)))
         } else {
-            effective = .period(
-                Period(
-                    end: FHIRPrimitive(try? DateTime(dateFormatter.string(from: endDate))),
-                    start: FHIRPrimitive(try? DateTime(dateFormatter.string(from: startDate)))
-                )
-            )
+            effective = .period(Period(
+                end: FHIRPrimitive(try DateTime(date: endDate, timeZone: timeZone)),
+                start: FHIRPrimitive(try DateTime(date: startDate, timeZone: timeZone))
+            ))
         }
     }
     
-    func setIssued(on date: Date) {
-        issued = FHIRPrimitive(try? Instant(date: date))
+    func setIssued(on date: Date) throws {
+        issued = FHIRPrimitive(try Instant(date: date))
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
@@ -39,7 +39,7 @@ class HKCategorySampleTests: XCTestCase {
             end: try endDate,
             metadata: metadata
         )
-        return try XCTUnwrap(categorySample.resource.get(if: Observation.self))
+        return try XCTUnwrap(categorySample.resource().get(if: Observation.self))
     }
 
     func createCategoryCoding(

--- a/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
@@ -49,7 +49,7 @@ class HKCorrelationTests: XCTestCase {
             objects: [systolicBloodPressure, diastolicBloodPressure]
         )
         
-        let observation = try XCTUnwrap(correlation.resource.get(if: Observation.self))
+        let observation = try XCTUnwrap(correlation.resource().get(if: Observation.self))
 
         XCTAssertEqual(1, observation.component?.filter {
             $0.value == .quantity(
@@ -89,6 +89,6 @@ class HKCorrelationTests: XCTestCase {
             end: try endDate,
             objects: [vitaminC]
         )
-        XCTAssertThrowsError(try correlation.resource)
+        XCTAssertThrowsError(try correlation.resource())
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -42,7 +42,7 @@ class HKQuantitySampleTests: XCTestCase {
             end: try endDate,
             metadata: metadata
         )
-        return try XCTUnwrap(quantitySample.resource.get(if: Observation.self))
+        return try XCTUnwrap(quantitySample.resource().get(if: Observation.self))
     }
     
     func createCoding(
@@ -2693,7 +2693,7 @@ class HKQuantitySampleTests: XCTestCase {
             end: try endDate
         )
         XCTAssertThrowsError(
-            try quantitySample.resource.get(if: Observation.self)
+            try quantitySample.resource().get(if: Observation.self)
         )
     }
     
@@ -2713,7 +2713,7 @@ class HKQuantitySampleTests: XCTestCase {
         )
         
         XCTAssertThrowsError(
-            try correlation.resource
+            try correlation.resource()
         )
     }
     
@@ -2725,7 +2725,7 @@ class HKQuantitySampleTests: XCTestCase {
                 expirationDate: nil,
                 device: nil,
                 metadata: nil
-            ).resource
+            ).resource()
         )
     }
     

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -57,6 +57,28 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
+    func testResourceComputedPropertyForward() throws {
+        let observation1 = try createObservationFrom(
+            type: HKQuantityType(.bloodGlucose),
+            quantity: HKQuantity(unit: HKUnit(from: "mg/dL"), doubleValue: 99)
+        )
+        let observation2: Observation = try {
+            let quantitySample = HKQuantitySample(
+                type: HKQuantityType(.bloodGlucose),
+                quantity: HKQuantity(unit: HKUnit(from: "mg/dL"), doubleValue: 99),
+                start: try startDate,
+                end: try endDate,
+                metadata: [:]
+            )
+            return try XCTUnwrap(quantitySample.resource.get(if: Observation.self))
+        }()
+        
+        observation2.issued = observation1.issued
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        XCTAssertEqual(try encoder.encode(observation1), try encoder.encode(observation1))
+    }
+    
     func testBloodGlucose() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.bloodGlucose),

--- a/Tests/HealthKitOnFHIRTests/HKWorkoutTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKWorkoutTests.swift
@@ -138,7 +138,7 @@ class HKWorkoutTests: XCTestCase {
                 end: try endDate
             )
 
-            let observation = try XCTUnwrap(workoutSample.resource.get(if: Observation.self))
+            let observation = try XCTUnwrap(workoutSample.resource().get(if: Observation.self))
             let expectedValue = createCodeableConcept(
                 code: try activityType.workoutTypeDescription,
                 system: "http://developer.apple.com/documentation/healthkit"

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable import HealthKitOnFHIR
+import HealthKitOnFHIR
 import SwiftUI
 
 

--- a/Tests/UITests/TestApp/Views/ContentView.swift
+++ b/Tests/UITests/TestApp/Views/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
                     NavigationLink("Electrocardiogram", destination: ElectrocardiogramTestView())
                     NavigationLink("Health Records", destination: HealthRecordsTestView())
                     NavigationLink("Create Workout", destination: CreateWorkoutView())
+                    NavigationLink("Export Data", destination: ExportDataView())
                 }
             }
             .navigationBarTitle("HealthKitOnFHIR Tests")

--- a/Tests/UITests/TestApp/Views/ExportDataView.swift
+++ b/Tests/UITests/TestApp/Views/ExportDataView.swift
@@ -1,0 +1,108 @@
+//
+// This source file is part of the HealthKitOnFHIR open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKit
+import HealthKitOnFHIR
+import SwiftUI
+
+
+struct ExportDataView: View {
+    private enum ViewState {
+        case idle
+        case processing
+        case failed(any Error)
+        
+        var isIdle: Bool {
+            switch self {
+            case .idle:
+                true
+            case .processing, .failed:
+                false
+            }
+        }
+    }
+    
+    private let healthStore = HKHealthStore()
+    
+    @State private var viewState: ViewState = .idle
+    @State private var generateResourcesDuration: TimeInterval?
+    
+    var body: some View {
+        Form {
+            Section("Actions") {
+                actionsSectionContent
+            }
+            if let generateResourcesDuration {
+                Section {
+                    LabeledContent("genResoueces", value: "\(generateResourcesDuration) sec")
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder private var actionsSectionContent: some View {
+        Button("Ask for Authorization") {
+            runAsync {
+                try await healthStore.requestAuthorization(
+                    toShare: [],
+                    read: [HKQuantityType(.activeEnergyBurned), HKQuantityType(.stepCount), HKQuantityType(.appleExerciseTime)]
+                )
+            }
+        }
+        .disabled(!viewState.isIdle)
+        Button("Query Samples") {
+            runAsync {
+                let fetchStartTS = CACurrentMediaTime()
+                let samples = try await healthStore.query(.init(.appleExerciseTime))
+                let fetchEndTS = CACurrentMediaTime()
+                print("did fetch samples (#=\(samples.count)) (took \(fetchEndTS - fetchStartTS) sec)")
+                let mapResourcesStartTS = CACurrentMediaTime()
+                _ = try samples.mapIntoResourceProxies()
+                let mapResourcesEndTS = CACurrentMediaTime()
+                print("did turn into resources (took \(mapResourcesEndTS - mapResourcesStartTS) sec)")
+                await MainActor.run {
+                    generateResourcesDuration = mapResourcesEndTS - mapResourcesStartTS
+                }
+            }
+        }
+        .disabled(!viewState.isIdle)
+    }
+    
+    private func runAsync(_ operation: @Sendable @escaping () async throws -> Void) {
+        precondition(viewState.isIdle)
+        Task {
+            viewState = .processing
+            do {
+                try await operation()
+                viewState = .idle
+            } catch {
+                viewState = .failed(error)
+            }
+        }
+    }
+}
+
+
+extension HKHealthStore {
+    func query(_ sampleType: HKQuantityType) async throws -> [HKQuantitySample] {
+        let cal = Calendar.current
+        let predicate = HKSamplePredicate.quantitySample(
+            type: sampleType
+//            predicate: HKQuery.predicateForSamples(
+//                withStart: cal.startOfDay(for: .now),
+//                end: cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: .now))!
+//            )
+        )
+        let descriptor = HKSampleQueryDescriptor(
+            predicates: [predicate],
+            sortDescriptors: [SortDescriptor(\.startDate, order: .forward)]
+        )
+        return try await descriptor.result(for: self)
+    }
+}

--- a/Tests/UITests/TestApp/Views/HealthRecordsTestView.swift
+++ b/Tests/UITests/TestApp/Views/HealthRecordsTestView.swift
@@ -60,7 +60,7 @@ struct HealthRecordsTestView: View {
         let resources: [Resource] = try await manager.readHealthRecords(type: type)
             .compactMap { sample in
                 do {
-                    return try sample.resource.get()
+                    return try sample.resource().get()
                 } catch {
                     print(error.localizedDescription)
                 }

--- a/Tests/UITests/TestApp/Views/ReadDataView.swift
+++ b/Tests/UITests/TestApp/Views/ReadDataView.swift
@@ -40,7 +40,7 @@ struct ReadDataView: View {
         
         let observations = try await manager.readStepCount()
             .compactMap { sample in
-                try? sample.resource.get()
+                try? sample.resource().get()
             }
 
         let encoder = JSONEncoder()

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,25 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		272A31F62B092A6200735827 /* CreateWorkoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272A31F52B092A6200735827 /* CreateWorkoutView.swift */; };
-		273373FD295BA8B80062EB05 /* HealthRecordsTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273373FC295BA8B80062EB05 /* HealthRecordsTestView.swift */; };
-		2765017029319B2100644064 /* HealthKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2765016F29319B2100644064 /* HealthKitManager.swift */; };
-		2765017229319E3000644064 /* WriteDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2765017129319E3000644064 /* WriteDataView.swift */; };
-		276501762931A58700644064 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276501752931A58700644064 /* ContentView.swift */; };
-		276501782931A82F00644064 /* ReadDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276501772931A82F00644064 /* ReadDataView.swift */; };
-		2790F40A29326CE90024213F /* JSONView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2790F40929326CE90024213F /* JSONView.swift */; };
 		2F1B52D42A4F78A5003AE151 /* XCTHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F1B52D32A4F78A5003AE151 /* XCTHealthKit */; };
 		2F1B52D72A4F7909003AE151 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F1B52D62A4F7909003AE151 /* XCTestExtensions */; };
-		2F5425F32951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5425F22951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift */; };
-		2F5425F62951AE2600B5DAC2 /* HKElectrocardiogram+Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5425F42951AD1D00B5DAC2 /* HKElectrocardiogram+Context.swift */; };
 		2F68C3C8292EA52000B3E12C /* HealthKitOnFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2F68C3C7292EA52000B3E12C /* HealthKitOnFHIR */; };
-		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
-		2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431229130A8C005D2B8F /* TestAppUITests.swift */; };
-		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,25 +23,26 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		272A31F52B092A6200735827 /* CreateWorkoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateWorkoutView.swift; sourceTree = "<group>"; };
-		273373FC295BA8B80062EB05 /* HealthRecordsTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthRecordsTestView.swift; sourceTree = "<group>"; };
-		2765016F29319B2100644064 /* HealthKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitManager.swift; sourceTree = "<group>"; };
-		2765017129319E3000644064 /* WriteDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteDataView.swift; sourceTree = "<group>"; };
-		276501752931A58700644064 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		276501772931A82F00644064 /* ReadDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadDataView.swift; sourceTree = "<group>"; };
-		2790F40929326CE90024213F /* JSONView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONView.swift; sourceTree = "<group>"; };
-		2F01E8CD291490B80089C46B /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
-		2F01E8CE291493560089C46B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2F1B52D82A4F7D93003AE151 /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
-		2F5425F22951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectrocardiogramTestView.swift; sourceTree = "<group>"; };
-		2F5425F42951AD1D00B5DAC2 /* HKElectrocardiogram+Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HKElectrocardiogram+Context.swift"; sourceTree = "<group>"; };
 		2F68C3C6292E9F8F00B3E12C /* HealthKitOnFHIR */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = HealthKitOnFHIR; path = ../..; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F8A431229130A8C005D2B8F /* TestAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppUITests.swift; sourceTree = "<group>"; };
-		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		80E246092DABA6A600423C4B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Support Files/Info.plist",
+			);
+			target = 2F6D139128F5F384007C25D6 /* TestApp */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		80E245FA2DABA6A600423C4B /* TestApp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (80E246092DABA6A600423C4B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TestApp; sourceTree = "<group>"; };
+		80E2460B2DABA6A900423C4B /* TestAppUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TestAppUITests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		2F6D138F28F5F384007C25D6 /* Frameworks */ = {
@@ -81,8 +70,8 @@
 			children = (
 				2F1B52D82A4F7D93003AE151 /* TestApp.xctestplan */,
 				2F68C3C6292E9F8F00B3E12C /* HealthKitOnFHIR */,
-				2F6D139428F5F384007C25D6 /* TestApp */,
-				2F6D13AF28F5F386007C25D6 /* TestAppUITests */,
+				80E245FA2DABA6A600423C4B /* TestApp */,
+				80E2460B2DABA6A900423C4B /* TestAppUITests */,
 				2F6D139328F5F384007C25D6 /* Products */,
 				2F6D13C228F5F3BE007C25D6 /* Frameworks */,
 			);
@@ -97,55 +86,11 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		2F6D139428F5F384007C25D6 /* TestApp */ = {
-			isa = PBXGroup;
-			children = (
-				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
-				2765016F29319B2100644064 /* HealthKitManager.swift */,
-				2F5425F42951AD1D00B5DAC2 /* HKElectrocardiogram+Context.swift */,
-				2FBE356C29399F37002EE0D5 /* Views */,
-				2FBE356B29399ED1002EE0D5 /* Support Files */,
-			);
-			path = TestApp;
-			sourceTree = "<group>";
-		};
-		2F6D13AF28F5F386007C25D6 /* TestAppUITests */ = {
-			isa = PBXGroup;
-			children = (
-				2F8A431229130A8C005D2B8F /* TestAppUITests.swift */,
-			);
-			path = TestAppUITests;
-			sourceTree = "<group>";
-		};
 		2F6D13C228F5F3BE007C25D6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		2FBE356B29399ED1002EE0D5 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				2F01E8CE291493560089C46B /* Info.plist */,
-				2F01E8CD291490B80089C46B /* TestApp.entitlements */,
-				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
-			);
-			path = "Support Files";
-			sourceTree = "<group>";
-		};
-		2FBE356C29399F37002EE0D5 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				276501752931A58700644064 /* ContentView.swift */,
-				272A31F52B092A6200735827 /* CreateWorkoutView.swift */,
-				2765017129319E3000644064 /* WriteDataView.swift */,
-				276501772931A82F00644064 /* ReadDataView.swift */,
-				2790F40929326CE90024213F /* JSONView.swift */,
-				2F5425F22951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift */,
-				273373FC295BA8B80062EB05 /* HealthRecordsTestView.swift */,
-			);
-			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -162,6 +107,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				80E245FA2DABA6A600423C4B /* TestApp */,
 			);
 			name = TestApp;
 			packageProductDependencies = (
@@ -183,6 +131,9 @@
 			);
 			dependencies = (
 				2F6D13AE28F5F386007C25D6 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				80E2460B2DABA6A900423C4B /* TestAppUITests */,
 			);
 			name = TestAppUITests;
 			packageProductDependencies = (
@@ -240,7 +191,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -258,16 +208,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				272A31F62B092A6200735827 /* CreateWorkoutView.swift in Sources */,
-				2790F40A29326CE90024213F /* JSONView.swift in Sources */,
-				2765017029319B2100644064 /* HealthKitManager.swift in Sources */,
-				2F5425F62951AE2600B5DAC2 /* HKElectrocardiogram+Context.swift in Sources */,
-				2F5425F32951AB7B00B5DAC2 /* ElectrocardiogramTestView.swift in Sources */,
-				273373FD295BA8B80062EB05 /* HealthRecordsTestView.swift in Sources */,
-				276501762931A58700644064 /* ContentView.swift in Sources */,
-				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
-				276501782931A82F00644064 /* ReadDataView.swift in Sources */,
-				2765017229319E3000644064 /* WriteDataView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -275,7 +215,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F8A431329130A8C005D2B8F /* TestAppUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -487,7 +426,6 @@
 		2F6D13BD28F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -506,7 +444,6 @@
 		2F6D13BE28F5F386007C25D6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;


### PR DESCRIPTION
# vastly improve HKSample → ResourceProxy performance

## :recycle: Current situation & Problem
HealthKitOnFHIR defines a `HKSample` extension to create a `ResourceProxy` for a sample.
Parts of this process are currently very slow, namely the date handling when creating the `Observation`.
When operating only on a small number of samples, this isn't really noticable, but for larger amounts of samples it does start to add up.

There are 2 performance bottlenecks:
1. Use of `DateFormatter`s when creating the `FHIRPrimitive<DateTime>` objects
  - sub-issue: the `DateFormatter`s currently are re-created every time the `resource()` function is called — creating `DateFormatter` instances is very expensive!
  - using a `DateFormatter` here is also not really necessary; the code currently turns a `Date` into a `String`, and then passes that to FHIR's `DateTime` init to parse it back into a date.
2. The `issued` date (a `FHIRPrimitive<Instant>`) is re-created for every `HKSample` in the collection being mapped into `ResourceProxy` objects, which incurs unnecessary overhead, since they will all end up representing essentially the exact same date.

This PR fixes these bottlenecks, thereby vastly improving the performance of turning `HKSample` instances into `ResourceProxy` instances.

We do this by:
1. Getting rid of the `DateFormatter`, and instead directly using `DateTime.init(date:timeZone:)`
2. Providing the following extensions on `Sequence` as optimization points when operating on multiple `HKSample`s:
    - `Sequence.mapIntoResourceProxies()`
    - `Sequence.compactMapIntoResourceProxies()`
    - These behave the exact same way as manually calling eg `.map { try $0.resourceProxy }`, except that they are significantly faster since they can use the same `issued` date for all resource proxies.

I did some benchmarking on my iPhone, mapping 140k step count samples from `HKSample` objects into `ResourceProxy` objects (using a release build; the measured time is just the resource creation and excludes HealthKit fetching):
- the old version took 12.35 seconds
- the new version takes 1.36 seconds

Note: This PR also deprecates `HKSample.resource` as a computed property, and turns it into a function. The reasoning here is that computed properties should ideally only be used for cheap computations where it's ok if you perform it multiple times. Having it be a function IMO indicates to the caller that this is a potentially expensive operation.

## :gear: Release Notes
- Deprecated the `HKSample.resource` property in favor of a `HKSample.resource()` function
- Improved the performance of turning `HKSample`s into `ResourceProxy`s
- Added `Sequence.mapIntoResourceProxies()` and `Sequence.compactMapIntoResourceProxies()`, to allow for even better performance when operating on large quantities of samples.


## :books: Documentation
The new code is documented.

## :white_check_mark: Testing
the new code is tested.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
