### PR TITLE
more sample types

### DIFF
--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/FHIRObservationBuildable.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/FHIRObservationBuildable.swift
@@ -1,0 +1,22 @@
+//
+// This source file is part of the HealthKitOnFHIR open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+import ModelsR4
+
+
+/// A Type that can be used to build up a FHIR`Observation`.
+protocol FHIRObservationBuildable {
+    func build(_ observation: Observation, mapping: HKSampleMapping) throws
+}
+
+extension FHIRObservationBuildable {
+    func build(_ observation: Observation) throws {
+        try build(observation, mapping: .default)
+    }
+}

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/FHIRObservationBuildable.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/FHIRObservationBuildable.swift
@@ -10,7 +10,7 @@ import HealthKit
 import ModelsR4
 
 
-/// A Type that can be used to build up a FHIR`Observation`.
+/// A Type that can be used to build up a FHIR `Observation`.
 protocol FHIRObservationBuildable {
     func build(_ observation: Observation, mapping: HKSampleMapping) throws
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/FHIRObservationBuildable.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/FHIRObservationBuildable.swift
@@ -14,9 +14,3 @@ import ModelsR4
 protocol FHIRObservationBuildable {
     func build(_ observation: Observation, mapping: HKSampleMapping) throws
 }
-
-extension FHIRObservationBuildable {
-    func build(_ observation: Observation) throws {
-        try build(observation, mapping: .default)
-    }
-}

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategorySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategorySample+Observation.swift
@@ -167,7 +167,7 @@ extension HKCategoryTypeIdentifier {
             case .moodChanges, .sleepChanges:
                 return .init(valueType: HKCategoryValuePresence.self)
             default:
-                if #available(iOS 18.0, *), self == .bleedingDuringPregnancy || self == .bleedingAfterPregnancy {
+                if #available(iOS 18.0, macOS 15.0, watchOS 11.0, *), self == .bleedingDuringPregnancy || self == .bleedingAfterPregnancy {
                     return .init(valueType: HKCategoryValueVaginalBleeding.self)
                 } else {
                     throw HealthKitOnFHIRError.notSupported

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategorySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategorySample+Observation.swift
@@ -10,120 +10,169 @@ import HealthKit
 import ModelsR4
 
 
-extension HKCategorySample {
-    // Disabled the following rules as this function is readable
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
-    func buildCategoryObservation(
-        _ observation: inout Observation,
-        mappings: HKSampleMapping = HKSampleMapping.default
-    ) throws {
-        guard let mapping = mappings.categorySampleMapping[self.categoryType] else {
+extension HKCategorySample: FHIRObservationBuildable {
+    func build(_ observation: Observation, mapping: HKSampleMapping) throws {
+        guard let mapping = mapping.categorySampleMapping[self.categoryType] else {
             throw HealthKitOnFHIRError.notSupported
         }
-
-        let valueString: String?
-        switch self.categoryType {
-        case HKCategoryType(.appetiteChanges):
-            valueString = try HKCategoryValueAppetiteChanges(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.appleStandHour):
-            valueString = try HKCategoryValueAppleStandHour(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.appleWalkingSteadinessEvent):
-            valueString = try HKCategoryValueAppleWalkingSteadinessEvent(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.cervicalMucusQuality):
-            valueString = try HKCategoryValueCervicalMucusQuality(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.contraceptive):
-            valueString = try HKCategoryValueContraceptive(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.environmentalAudioExposureEvent):
-            valueString = try HKCategoryValueEnvironmentalAudioExposureEvent(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.headphoneAudioExposureEvent):
-            valueString = try HKCategoryValueHeadphoneAudioExposureEvent(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.lowCardioFitnessEvent):
-            valueString = try HKCategoryValueLowCardioFitnessEvent(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.menstrualFlow):
-            valueString = try HKCategoryValueMenstrualFlow(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.ovulationTestResult):
-            valueString = try HKCategoryValueOvulationTestResult(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.pregnancyTestResult):
-            valueString = try HKCategoryValuePregnancyTestResult(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.progesteroneTestResult):
-            valueString = try HKCategoryValueProgesteroneTestResult(rawValue: self.value)?.categoryValueDescription
-        case HKCategoryType(.sleepAnalysis):
-            valueString = try HKCategoryValueSleepAnalysis(rawValue: self.value)?.categoryValueDescription
-        case
-            HKCategoryType(.abdominalCramps),
-            HKCategoryType(.acne),
-            HKCategoryType(.bladderIncontinence),
-            HKCategoryType(.bloating),
-            HKCategoryType(.breastPain),
-            HKCategoryType(.chestTightnessOrPain),
-            HKCategoryType(.chills),
-            HKCategoryType(.constipation),
-            HKCategoryType(.coughing),
-            HKCategoryType(.dizziness),
-            HKCategoryType(.drySkin),
-            HKCategoryType(.fainting),
-            HKCategoryType(.fatigue),
-            HKCategoryType(.fever),
-            HKCategoryType(.generalizedBodyAche),
-            HKCategoryType(.hairLoss),
-            HKCategoryType(.headache),
-            HKCategoryType(.heartburn),
-            HKCategoryType(.hotFlashes),
-            HKCategoryType(.lossOfSmell),
-            HKCategoryType(.lossOfTaste),
-            HKCategoryType(.lowerBackPain),
-            HKCategoryType(.memoryLapse),
-            HKCategoryType(.nausea),
-            HKCategoryType(.nightSweats),
-            HKCategoryType(.pelvicPain),
-            HKCategoryType(.rapidPoundingOrFlutteringHeartbeat),
-            HKCategoryType(.runnyNose),
-            HKCategoryType(.shortnessOfBreath),
-            HKCategoryType(.sinusCongestion),
-            HKCategoryType(.skippedHeartbeat),
-            HKCategoryType(.soreThroat),
-            HKCategoryType(.vaginalDryness),
-            HKCategoryType(.vomiting),
-            HKCategoryType(.wheezing):
-            // Samples of these types carry values of
-            // HKCategoryValueSeverity
-            valueString = try HKCategoryValueSeverity(rawValue: self.value)?.categoryValueDescription
-        case
-            HKCategoryType(.moodChanges),
-            HKCategoryType(.sleepChanges):
-            // Samples of these types carry values of
-            // HKCategoryValuePresence
-            valueString = try HKCategoryValuePresence(rawValue: self.value)?.categoryValueDescription
-        case
-            HKCategoryType(.irregularHeartRhythmEvent),
-            HKCategoryType(.lowHeartRateEvent),
-            HKCategoryType(.highHeartRateEvent),
-            HKCategoryType(.mindfulSession),
-            HKCategoryType(.toothbrushingEvent),
-            HKCategoryType(.handwashingEvent),
-            HKCategoryType(.sexualActivity),
-            HKCategoryType(.intermenstrualBleeding),
-            HKCategoryType(.infrequentMenstrualCycles),
-            HKCategoryType(.irregularMenstrualCycles),
-            HKCategoryType(.persistentIntermenstrualBleeding),
-            HKCategoryType(.prolongedMenstrualPeriods),
-            HKCategoryType(.lactation):
-            // Samples of these types do not carry any value,
-            // nor associated metadata, so we use the category
-            // identifier as the value.
-            valueString = self.categoryType.description
-        default:
-            throw HealthKitOnFHIRError.notSupported
-        }
-        
-        guard let valueString else {
-            throw HealthKitOnFHIRError.notSupported
-        }
-
+        let assocDataInfo = try categoryType.associatedDataInfo
         for code in mapping.codings {
             observation.appendCoding(code.coding)
         }
+        if let valueType = assocDataInfo.valueType {
+            guard let value = valueType.init(rawValue: self.value) else {
+                throw HealthKitOnFHIRError.invalidValue
+            }
+            observation.setValue(try value.fhirCategoryValue)
+        } else {
+            // If the sample doesn't have a value type associated with it, we set the value to the category identifier
+            observation.setValue(self.categoryType.identifier)
+        }
+        for metadataKey in assocDataInfo.metadataKeys {
+            guard let value = self.metadata?[metadataKey] else {
+                continue
+            }
+            if let quantity = value as? HKQuantity {
+                observation.appendComponent(try quantity.buildObservationComponent(for: HKQuantityType(.vo2Max)))
+            } else if let value = value as? Bool {
+                guard let coding = HKCategoryType.coding(forMetadataKey: metadataKey) else {
+                    continue
+                }
+                observation.appendComponent(ObservationComponent(
+                    code: CodeableConcept(coding: [coding]),
+                    value: .boolean(value.asPrimitive())
+                ))
+            } else {
+                continue
+            }
+        }
+    }
+}
 
-        observation.setValue(valueString)
+extension HKCategoryType {
+    fileprivate static func coding(forMetadataKey key: String) -> Coding? {
+        switch key {
+        case HKMetadataKeyMenstrualCycleStart:
+            Coding(
+                code: key.asFHIRStringPrimitive(),
+                display: "Menstrual Cycle Start".asFHIRStringPrimitive(),
+                system: "http://developer.apple.com/documentation/healthkit".asFHIRURIPrimitive()
+            )
+        case HKMetadataKeySexualActivityProtectionUsed:
+            Coding(
+                code: key.asFHIRStringPrimitive(),
+                display: "Sexual Activity: Protection Used".asFHIRStringPrimitive(),
+                system: "http://developer.apple.com/documentation/healthkit".asFHIRURIPrimitive()
+            )
+        default:
+            nil
+        }
+    }
+}
+
+
+extension HKCategoryType {
+    /// Information about the associated data carried by a sample of a specific category type.
+    struct AssociatedDataInfo {
+        static var noDataCarried: Self { .init(valueType: nil) }
+        
+        let valueType: (any FHIRCompatibleHKCategoryValueType.Type)?
+        let metadataKeys: Set<String>
+        
+        init(valueType: (any FHIRCompatibleHKCategoryValueType.Type)?, metadataKeys: Set<String> = []) {
+            self.valueType = valueType
+            self.metadataKeys = metadataKeys
+        }
+    }
+    
+    /// The category type's associated (FHIR-compatible) Category Value Type.
+    ///
+    /// - throws: if the category type is unknown to HealthKitOnFHIR.
+    var associatedDataInfo: AssociatedDataInfo {
+        get throws {
+            try HKCategoryTypeIdentifier(rawValue: self.identifier).associatedDataInfo
+        }
+    }
+}
+
+
+extension HKCategoryTypeIdentifier {
+    /// The category type's associated (FHIR-compatible) Category Value Type.
+    ///
+    /// - throws: if the category type is unknown to HealthKitOnFHIR.
+    var associatedDataInfo: HKCategoryType.AssociatedDataInfo {
+        get throws {
+            switch self {
+            case .appleStandHour:
+                return .init(valueType: HKCategoryValueAppleStandHour.self)
+            case .environmentalAudioExposureEvent:
+                return .init(valueType: HKCategoryValueEnvironmentalAudioExposureEvent.self)
+            case .headphoneAudioExposureEvent:
+                return .init(valueType: HKCategoryValueHeadphoneAudioExposureEvent.self)
+            case .highHeartRateEvent, .lowHeartRateEvent:
+                return .init(
+                    valueType: nil,
+                    metadataKeys: [HKMetadataKeyHeartRateEventThreshold]
+                )
+            case .irregularHeartRhythmEvent:
+                return .noDataCarried
+            case .lowCardioFitnessEvent:
+                return .init(
+                    valueType: HKCategoryValueLowCardioFitnessEvent.self,
+                    metadataKeys: [HKMetadataKeyVO2MaxValue, HKMetadataKeyLowCardioFitnessEventThreshold]
+                )
+            case .mindfulSession:
+                return .noDataCarried
+            case .appleWalkingSteadinessEvent:
+                return .init(valueType: HKCategoryValueAppleWalkingSteadinessEvent.self)
+            case .handwashingEvent, .toothbrushingEvent:
+                return .noDataCarried
+            case .cervicalMucusQuality:
+                return .init(valueType: HKCategoryValueCervicalMucusQuality.self)
+            case .contraceptive:
+                return .init(valueType: HKCategoryValueContraceptive.self)
+            case .infrequentMenstrualCycles, .intermenstrualBleeding, .irregularMenstrualCycles, .lactation, .persistentIntermenstrualBleeding:
+                return .noDataCarried
+            case .menstrualFlow:
+                return .init(
+                    valueType: HKCategoryValueMenstrualFlow.self,
+                    metadataKeys: [HKMetadataKeyMenstrualCycleStart]
+                )
+            case .ovulationTestResult:
+                return .init(valueType: HKCategoryValueOvulationTestResult.self)
+            case .pregnancy:
+                return .noDataCarried
+            case .pregnancyTestResult:
+                return .init(valueType: HKCategoryValuePregnancyTestResult.self)
+            case .progesteroneTestResult:
+                return .init(valueType: HKCategoryValueProgesteroneTestResult.self)
+            case .prolongedMenstrualPeriods:
+                return .noDataCarried
+            case .sexualActivity:
+                return .init(valueType: nil, metadataKeys: [HKMetadataKeySexualActivityProtectionUsed])
+            case .sleepAnalysis:
+                return .init(valueType: HKCategoryValueSleepAnalysis.self)
+            case .abdominalCramps:
+                return .init(valueType: HKCategoryValueSeverity.self)
+            case .acne:
+                return .init(valueType: HKCategoryValueSeverity.self)
+            case .appetiteChanges:
+                return .init(valueType: HKCategoryValueAppetiteChanges.self)
+            case .bladderIncontinence, .bloating, .breastPain, .chestTightnessOrPain, .chills, .constipation,
+                    .coughing, .diarrhea, .dizziness, .drySkin, .fainting, .fatigue, .fever, .generalizedBodyAche, .hairLoss,
+                    .headache, .heartburn, .hotFlashes, .lossOfSmell, .lossOfTaste, .lowerBackPain, .memoryLapse, .nausea,
+                    .nightSweats, .pelvicPain, .rapidPoundingOrFlutteringHeartbeat, .runnyNose, .shortnessOfBreath, .sinusCongestion,
+                    .skippedHeartbeat, .soreThroat, .vaginalDryness, .vomiting, .wheezing:
+                return .init(valueType: HKCategoryValueSeverity.self)
+            case .moodChanges, .sleepChanges:
+                return .init(valueType: HKCategoryValuePresence.self)
+            default:
+                if #available(iOS 18.0, *), self == .bleedingDuringPregnancy || self == .bleedingAfterPregnancy {
+                    return .init(valueType: HKCategoryValueVaginalBleeding.self)
+                } else {
+                    throw HealthKitOnFHIRError.notSupported
+                }
+            }
+        }
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
@@ -9,24 +9,39 @@
 import HealthKit
 
 
-protocol HKCategoryValueDescription: CustomStringConvertible {
-    var categoryValueDescription: String { get throws }
+/// Models a value type used by a `HKCategoryType`.
+protocol FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String { get throws }
+    
+    init?(rawValue: Int)
 }
 
-extension HKCategoryValueDescription {
-    /// A string description of the HKCategoryValue case
-    public var description: String {
-        do {
-            return try categoryValueDescription
-        } catch {
-            return "undefined"
+
+@available(iOS 18.0, *)
+extension HKCategoryValueVaginalBleeding: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
+        get throws {
+            switch self {
+            case .unspecified:
+                return "unspecified"
+            case .light:
+                return "light"
+            case .medium:
+                return "medium"
+            case .heavy:
+                return "heavy"
+            case .none:
+                return "none"
+            @unknown default:
+                throw HealthKitOnFHIRError.invalidValue
+            }
         }
     }
 }
 
-extension HKCategoryValueCervicalMucusQuality: @retroactive CustomStringConvertible {}
-extension HKCategoryValueCervicalMucusQuality: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueCervicalMucusQuality: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .dry:
@@ -46,9 +61,9 @@ extension HKCategoryValueCervicalMucusQuality: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueMenstrualFlow: @retroactive CustomStringConvertible {}
-extension HKCategoryValueMenstrualFlow: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueMenstrualFlow: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .unspecified:
@@ -68,9 +83,9 @@ extension HKCategoryValueMenstrualFlow: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueOvulationTestResult: @retroactive CustomStringConvertible {}
-extension HKCategoryValueOvulationTestResult: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueOvulationTestResult: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .negative:
@@ -88,9 +103,9 @@ extension HKCategoryValueOvulationTestResult: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueContraceptive: @retroactive CustomStringConvertible {}
-extension HKCategoryValueContraceptive: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueContraceptive: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .unspecified:
@@ -114,9 +129,9 @@ extension HKCategoryValueContraceptive: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueSleepAnalysis: @retroactive CustomStringConvertible {}
-extension HKCategoryValueSleepAnalysis: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueSleepAnalysis: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .inBed:
@@ -138,9 +153,9 @@ extension HKCategoryValueSleepAnalysis: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueAppetiteChanges: @retroactive CustomStringConvertible {}
-extension HKCategoryValueAppetiteChanges: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueAppetiteChanges: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .unspecified:
@@ -158,9 +173,9 @@ extension HKCategoryValueAppetiteChanges: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueEnvironmentalAudioExposureEvent: @retroactive CustomStringConvertible {}
-extension HKCategoryValueEnvironmentalAudioExposureEvent: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueEnvironmentalAudioExposureEvent: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .momentaryLimit:
@@ -172,9 +187,9 @@ extension HKCategoryValueEnvironmentalAudioExposureEvent: HKCategoryValueDescrip
     }
 }
 
-extension HKCategoryValueHeadphoneAudioExposureEvent: @retroactive CustomStringConvertible {}
-extension HKCategoryValueHeadphoneAudioExposureEvent: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueHeadphoneAudioExposureEvent: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .sevenDayLimit:
@@ -186,9 +201,9 @@ extension HKCategoryValueHeadphoneAudioExposureEvent: HKCategoryValueDescription
     }
 }
 
-extension HKCategoryValueLowCardioFitnessEvent: @retroactive CustomStringConvertible {}
-extension HKCategoryValueLowCardioFitnessEvent: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueLowCardioFitnessEvent: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .lowFitness:
@@ -200,9 +215,9 @@ extension HKCategoryValueLowCardioFitnessEvent: HKCategoryValueDescription {
     }
 }
 
-extension HKAppleWalkingSteadinessClassification: @retroactive CustomStringConvertible {}
-extension HKAppleWalkingSteadinessClassification: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKAppleWalkingSteadinessClassification: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .ok:
@@ -218,9 +233,9 @@ extension HKAppleWalkingSteadinessClassification: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueAppleWalkingSteadinessEvent: @retroactive CustomStringConvertible {}
-extension HKCategoryValueAppleWalkingSteadinessEvent: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueAppleWalkingSteadinessEvent: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .initialLow:
@@ -238,9 +253,9 @@ extension HKCategoryValueAppleWalkingSteadinessEvent: HKCategoryValueDescription
     }
 }
 
-extension HKCategoryValuePregnancyTestResult: @retroactive CustomStringConvertible {}
-extension HKCategoryValuePregnancyTestResult: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValuePregnancyTestResult: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .negative:
@@ -256,9 +271,9 @@ extension HKCategoryValuePregnancyTestResult: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueProgesteroneTestResult: @retroactive CustomStringConvertible {}
-extension HKCategoryValueProgesteroneTestResult: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueProgesteroneTestResult: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .negative:
@@ -274,9 +289,9 @@ extension HKCategoryValueProgesteroneTestResult: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueAppleStandHour: @retroactive CustomStringConvertible {}
-extension HKCategoryValueAppleStandHour: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueAppleStandHour: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .stood:
@@ -290,9 +305,9 @@ extension HKCategoryValueAppleStandHour: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValueSeverity: @retroactive CustomStringConvertible {}
-extension HKCategoryValueSeverity: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValueSeverity: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .unspecified:
@@ -312,9 +327,9 @@ extension HKCategoryValueSeverity: HKCategoryValueDescription {
     }
 }
 
-extension HKCategoryValuePresence: @retroactive CustomStringConvertible {}
-extension HKCategoryValuePresence: HKCategoryValueDescription {
-    var categoryValueDescription: String {
+
+extension HKCategoryValuePresence: FHIRCompatibleHKCategoryValueType {
+    var fhirCategoryValue: String {
         get throws {
             switch self {
             case .present:

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
@@ -17,7 +17,7 @@ protocol FHIRCompatibleHKCategoryValueType {
 }
 
 
-@available(iOS 18.0, macOS 15.0, watchOS 11.0 *)
+@available(iOS 18.0, macOS 15.0, watchOS 11.0, *)
 extension HKCategoryValueVaginalBleeding: FHIRCompatibleHKCategoryValueType {
     var fhirCategoryValue: String {
         get throws {

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCategoryValue+String.swift
@@ -17,7 +17,7 @@ protocol FHIRCompatibleHKCategoryValueType {
 }
 
 
-@available(iOS 18.0, *)
+@available(iOS 18.0, macOS 15.0, watchOS 11.0 *)
 extension HKCategoryValueVaginalBleeding: FHIRCompatibleHKCategoryValueType {
     var fhirCategoryValue: String {
         get throws {

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKClinicalRecord+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKClinicalRecord+ResourceProxy.swift
@@ -17,14 +17,9 @@ extension HKClinicalRecord {
         guard let fhirResource = self.fhirResource else {
             throw HealthKitOnFHIRError.invalidFHIRResource
         }
-        
         guard fhirResource.fhirVersion == HKFHIRVersion.primaryR4() else {
             throw HealthKitOnFHIRError.unsupportedFHIRVersion
         }
-        
-        let decoder = JSONDecoder()
-        do {
-            return try decoder.decode(ResourceProxy.self, from: fhirResource.data)
-        }
+        return try JSONDecoder().decode(ResourceProxy.self, from: fhirResource.data)
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKCorrelationType+Observation.swift
@@ -10,31 +10,24 @@ import HealthKit
 import ModelsR4
 
 
-extension HKCorrelation {
-    func buildCorrelationObservation(
-        _ observation: inout Observation,
-        mappings: HKSampleMapping = HKSampleMapping.default
-    ) throws {
-        guard let mapping = mappings.correlationMapping[self.correlationType] else {
+extension HKCorrelation: FHIRObservationBuildable {
+    func build(_ observation: Observation, mapping: HKSampleMapping) throws {
+        guard let mapping = mapping.correlationMapping[self.correlationType] else {
             throw HealthKitOnFHIRError.notSupported
         }
-        
         for code in mapping.codings {
             observation.appendCoding(code.coding)
         }
-        
         for category in mapping.categories {
             observation.appendCategory(
                 CodeableConcept(coding: [category.coding])
             )
         }
-        
         for object in self.objects {
             guard let sample = object as? HKQuantitySample else {
                 throw HealthKitOnFHIRError.notSupported
             }
-            
-            try sample.buildQuantitySampleObservationComponent(&observation)
+            observation.appendComponent(try sample.quantity.buildObservationComponent(for: sample.quantityType))
         }
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -20,20 +20,6 @@ extension HKQuantitySample: FHIRObservationBuildable {
         }
         observation.setValue(quantity.buildQuantity(mapping: mapping))
     }
-    
-    
-//    func buildQuantitySampleObservationComponent(
-//        _ observation: Observation,
-//        mappings: [HKQuantityType: HKQuantitySampleMapping] = HKQuantitySampleMapping.default
-//    ) throws {
-//        guard let mapping = mappings[self.quantityType] else {
-//            throw HealthKitOnFHIRError.notSupported
-//        }
-//        
-//        let component = ObservationComponent(code: CodeableConcept(coding: mapping.codings.map(\.coding)))
-//        component.value = .quantity(quantity.buildQuantity(mapping: mapping))
-//        observation.appendComponent(component)
-//    }
 }
 
 

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -41,18 +41,6 @@ extension HKQuantity {
         )
     }
     
-    
-    func buildQuantity(
-        for quantityType: HKQuantityType,
-        mappings: [HKQuantityType: HKQuantitySampleMapping] = HKQuantitySampleMapping.default
-    ) throws -> Quantity {
-        guard let mapping = mappings[quantityType] else {
-            throw HealthKitOnFHIRError.notSupported
-        }
-        return self.buildQuantity(mapping: mapping)
-    }
-    
-    
     func buildQuantity(mapping: HKQuantitySampleMapping) -> Quantity {
         Quantity(
             code: mapping.unit.code?.asFHIRStringPrimitive(),

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantityType+Coding.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantityType+Coding.swift
@@ -23,7 +23,6 @@ extension HKQuantityType {
         guard let mapping = mappings[self] else {
             return []
         }
-        
         return mapping.codings.map(\.coding)
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -11,28 +11,21 @@ import ModelsR4
 
 
 extension HKSample {
-    /// Converts an `HKSample` into an FHIR  resource, encapsulated in a `ResourceProxy`
-    @available(
-        *, deprecated,
-         renamed: "resource()",
-         // swiftlint:disable:next line_length
-         message: "Important: When mapping an array of HKSample objects into ResourceProxies, for performance reasons always prefer 'Sequence.mapIntoResourceProxies()' or 'Sequence.compactMapIntoResourceProxies()'"
-    )
-    public var resource: ResourceProxy {
-        get throws {
-            try resource()
-        }
-    }
-    
-    
     /// A `ResourceProxy` containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
     ///
     /// - parameter mapping: A mapping to map `HKSample`s to corresponding FHIR observations allowing the customization of, e.g., codings and units. See ``HKSampleMapping``.
     /// - parameter issuedDate: `Instant` specifying when this version of the resource was made available. Defaults to `Date.now`.
     /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
     /// - throws: If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
+    ///
+    /// - Important: When mapping an array of HKSample objects into ResourceProxies, for performance reasons always prefer ``Swift/Sequence/mapIntoResourceProxies(using:)`` or ``Swift/Sequence/compactMapIntoResourceProxies(using:)``.
     public func resource(withMapping mapping: HKSampleMapping = .default, issuedDate: FHIRPrimitive<Instant>? = nil) throws -> ResourceProxy {
-        var observation = Observation(
+        #if !os(watchOS)
+        if let self = self as? HKClinicalRecord {
+            return try self.resource()
+        }
+        #endif
+        let observation = Observation(
             code: CodeableConcept(),
             status: FHIRPrimitive(.final)
         )
@@ -50,22 +43,9 @@ extension HKSample {
             try observation.setIssued(on: Date())
         }
         // Set specific data based on HealthKit type
-        switch self {
-        case let quantitySample as HKQuantitySample:
-            try quantitySample.buildQuantitySampleObservation(&observation, mappings: mapping)
-        case let correlation as HKCorrelation:
-            try correlation.buildCorrelationObservation(&observation, mappings: mapping)
-        case let categorySample as HKCategorySample:
-            try categorySample.buildCategoryObservation(&observation)
-        case let electrocardiogram as HKElectrocardiogram:
-            try electrocardiogram.buildObservation(&observation, mappings: mapping)
-        #if !os(watchOS)
-        case let clinicalRecord as HKClinicalRecord:
-            return try clinicalRecord.resource()
-        #endif
-        case let workout as HKWorkout:
-            try workout.buildWorkoutObservation(&observation)
-        default:
+        if let self = self as? any FHIRObservationBuildable {
+            try self.build(observation, mapping: mapping)
+        } else {
             throw HealthKitOnFHIRError.notSupported
         }
         return ResourceProxy(with: observation)

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKWorkout+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKWorkout+Observation.swift
@@ -10,36 +10,25 @@ import HealthKit
 import ModelsR4
 
 
-extension HKWorkout {
+extension HKWorkout: FHIRObservationBuildable {
     /// Generates an observation that captures the type of physical activity performed for a single instance of physical activity, based on https://build.fhir.org/ig/HL7/physical-activity/StructureDefinition-pa-observation-activity-measure.html
     /// Note:  An `HKWorkout` object can also act as a container for other `HKSample` objects, which will need to be converted to observations individually.
-    func buildWorkoutObservation(
-        _ observation: inout Observation,
-        mappings: HKSampleMapping = HKSampleMapping.default
-    ) throws {
-        let mapping = mappings.workoutSampleMapping
-
+    func build(_ observation: Observation, mapping: HKSampleMapping) throws {
+        let mapping = mapping.workoutSampleMapping
         for code in mapping.codings {
             observation.appendCoding(code.coding)
         }
-
         for category in mapping.categories {
-            observation.appendCategory(
-                CodeableConcept(coding: [category.coding])
-            )
+            observation.appendCategory(CodeableConcept(coding: [category.coding]))
         }
-        
-        let activityTypeString = self.workoutActivityType.description.asFHIRStringPrimitive()
-
         let valueCodeableConcept = CodeableConcept(
             coding: [
                 Coding(
-                    code: activityTypeString,
+                    code: try self.workoutActivityType.fhirWorkoutTypeValue.asFHIRStringPrimitive(),
                     system: "http://developer.apple.com/documentation/healthkit".asFHIRURIPrimitive()
                 )
             ]
         )
-
         observation.value = .codeableConcept(valueCodeableConcept)
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKWorkoutActivityType+String.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKWorkoutActivityType+String.swift
@@ -9,24 +9,8 @@
 import HealthKit
 
 
-protocol HKWorkoutActivityTypeDescription: CustomStringConvertible {
-    var workoutTypeDescription: String { get throws }
-}
-
-extension HKWorkoutActivityTypeDescription {
-    /// A string description of the HKWorkoutActivityType case
-    public var description: String {
-        do {
-            return try workoutTypeDescription
-        } catch {
-            return "undefined"
-        }
-    }
-}
-
-extension HKWorkoutActivityType: @retroactive CustomStringConvertible {}
-extension HKWorkoutActivityType: HKWorkoutActivityTypeDescription {
-    var workoutTypeDescription: String {
+extension HKWorkoutActivityType {
+    var fhirWorkoutTypeValue: String {
         get throws {
             switch self {
             case .americanFootball:

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
@@ -15,26 +15,23 @@ extension Observation {
     private func appendElement<T>(_ element: T, to collection: ReferenceWritableKeyPath<Observation, [T]?>) {
         // swiftlint:disable:previous discouraged_optional_collection
         // Unfortunately we need to use an optional collection here as the ModelsR4 modules uses optional collections in the Observation type.
-        
         guard self[keyPath: collection] != nil else {
             self[keyPath: collection] = [element]
             return
         }
-        
         self[keyPath: collection]?.append(element)
     }
+    
     
     private func appendElements<T>(_ elements: [T], to collection: ReferenceWritableKeyPath<Observation, [T]?>) {
         // swiftlint:disable:previous discouraged_optional_collection
         // Unfortunately we need to use an optional collection here as the ModelsR4 modules uses optional collections in the Observation type.
-        
         if self[keyPath: collection] == nil {
             self[keyPath: collection] = []
             self[keyPath: collection]?.reserveCapacity(elements.count)
         } else {
             self[keyPath: collection]?.reserveCapacity((self[keyPath: collection]?.count ?? 0) + elements.count)
         }
-        
         for element in elements {
             appendElement(element, to: collection)
         }

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -755,13 +755,7 @@
             ]
         },
         "HKCorrelationTypeIdentifierFood": {
-            "categories": [
-                {
-                    "code": "activity",
-                    "display": "Activity",
-                    "system": "http://terminology.hl7.org/CodeSystem/observation-category"
-                }
-            ],
+            "categories": [],
             "codings": [
                 {
                     "code": "80453-4",

--- a/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
+++ b/Sources/HealthKitOnFHIR/Resources/HKSampleMapping.json
@@ -151,6 +151,24 @@
                 }
             ]
         },
+        "HKCategoryTypeIdentifierBleedingAfterPregnancy": {
+            "codings": [
+                {
+                    "code": "HKCategoryTypeIdentifierBleedingAfterPregnancy",
+                    "display": "Bleeding After Pregnancy",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
+        "HKCategoryTypeIdentifierBleedingDuringPregnancy": {
+            "codings": [
+                {
+                    "code": "HKCategoryTypeIdentifierBleedingDuringPregnancy",
+                    "display": "Bleeding During Pregnancy",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
         "HKCategoryTypeIdentifierCervicalMucusQuality": {
             "codings": [
                 {
@@ -174,6 +192,15 @@
                 {
                     "code": "HKCategoryTypeIdentifierAudioExposureEvent",
                     "display": "Environmental Audio Exposure Event",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
+        "HKCategoryTypeIdentifierDiarrhea": {
+            "codings": [
+                {
+                    "code": "HKCategoryTypeIdentifierDiarrhea",
+                    "display": "Diarrhea",
                     "system": "http://developer.apple.com/documentation/healthkit"
                 }
             ]
@@ -214,6 +241,15 @@
                 }
             ]
         },
+        "HKCategoryTypeIdentifierPregnancy": {
+            "codings": [
+                {
+                    "code": "HKCategoryTypeIdentifierPregnancy",
+                    "display": "Pregnancy",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
         "HKCategoryTypeIdentifierPregnancyTestResult": {
             "codings": [
                 {
@@ -237,6 +273,15 @@
                 {
                     "code": "HKCategoryTypeIdentifierSleepAnalysis",
                     "display": "Sleep Analysis",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ]
+        },
+        "HKCategoryTypeIdentifierSleepApneaEvent": {
+            "codings": [
+                {
+                    "code": "HKCategoryTypeIdentifierSleepApneaEvent",
+                    "display": "Sleep Apnea Event",
                     "system": "http://developer.apple.com/documentation/healthkit"
                 }
             ]
@@ -708,6 +753,22 @@
                     "system": "http://loinc.org"
                 }
             ]
+        },
+        "HKCorrelationTypeIdentifierFood": {
+            "categories": [
+                {
+                    "code": "activity",
+                    "display": "Activity",
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+                }
+            ],
+            "codings": [
+                {
+                    "code": "80453-4",
+                    "display": "Food intake panel",
+                    "system": "http://loinc.org"
+                }
+            ]
         }
     },
     "HKQuantitySamples": {
@@ -761,6 +822,34 @@
                 "unit": "min"
             }
         },
+        "HKQuantityTypeIdentifierAppleSleepingBreathingDisturbances": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierAppleSleepingBreathingDisturbances",
+                    "display": "Apple Sleeping Breathing Disturbances",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "count",
+                "unit": "count"
+            }
+        },
+        "HKQuantityTypeIdentifierAppleSleepingWristTemperature": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierAppleSleepingWristTemperature",
+                    "display": "Apple Sleeping Wrist Temperature",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "Cel",
+                "hkunit": "degC",
+                "system": "http://unitsofmeasure.org",
+                "unit": "C"
+            }
+        },
         "HKQuantityTypeIdentifierAppleStandTime": {
             "codings": [
                 {
@@ -781,6 +870,21 @@
                 {
                     "code": "HKQuantityTypeIdentifierAppleWalkingSteadiness",
                     "display": "Apple Walking Steadiness",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "%",
+                "hkunit": "%",
+                "system": "http://unitsofmeasure.org",
+                "unit": "%"
+            }
+        },
+        "HKQuantityTypeIdentifierAtrialFibrillationBurden": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierAppleSleepingWristTemperature",
+                    "display": "Atrial Fibrillation Burden",
                     "system": "http://developer.apple.com/documentation/healthkit"
                 }
             ],
@@ -979,6 +1083,81 @@
                 "hkunit": "degC",
                 "system": "http://unitsofmeasure.org",
                 "unit": "C"
+            }
+        },
+        "HKQuantityTypeIdentifierCrossCountrySkiingSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierCrossCountrySkiingSpeed",
+                    "display": "Cross Country Skiing Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m/s",
+                "hkunit": "m/s",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m/s"
+            }
+        },
+        "HKQuantityTypeIdentifierCyclingCadence": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierCyclingCadence",
+                    "display": "Cycling Cadence",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "/min",
+                "hkunit": "count/min",
+                "system": "http://unitsofmeasure.org",
+                "unit": "r/min"
+            }
+        },
+        "HKQuantityTypeIdentifierCyclingFunctionalThresholdPower": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierCyclingFunctionalThresholdPower",
+                    "display": "Cycling Functional Threshold Power",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "W",
+                "hkunit": "W",
+                "system": "http://unitsofmeasure.org",
+                "unit": "watt"
+            }
+        },
+        "HKQuantityTypeIdentifierCyclingPower": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierCyclingPower",
+                    "display": "Cycling Power",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "W",
+                "hkunit": "W",
+                "system": "http://unitsofmeasure.org",
+                "unit": "watt"
+            }
+        },
+        "HKQuantityTypeIdentifierCyclingSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierCyclingFunctionalThresholdPower",
+                    "display": "Cycling Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "km/h",
+                "hkunit": "km/hr",
+                "system": "http://unitsofmeasure.org",
+                "unit": "km/h"
             }
         },
         "HKQuantityTypeIdentifierDietaryBiotin": {
@@ -1576,6 +1755,21 @@
                 "unit": "mg"
             }
         },
+        "HKQuantityTypeIdentifierDistanceCrossCountrySkiing": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierDistanceCrossCountrySkiing",
+                    "display": "Distance Cross Country Skiing",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
+            }
+        },
         "HKQuantityTypeIdentifierDistanceCycling": {
             "codings": [
                 {
@@ -1596,6 +1790,51 @@
                 {
                     "code": "HKQuantityTypeIdentifierDistanceDownhillSnowSports",
                     "display": "Distance Downhill Snow Sports",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
+            }
+        },
+        "HKQuantityTypeIdentifierDistancePaddleSports": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierDistancePaddleSports",
+                    "display": "Distance Paddle Sports",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
+            }
+        },
+        "HKQuantityTypeIdentifierDistanceRowing": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierDistanceRowing",
+                    "display": "Distance Rowing",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
+            }
+        },
+        "HKQuantityTypeIdentifierDistanceSkatingSports": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierDistanceSkatingSports",
+                    "display": "Distance Cross Country Skiing",
                     "system": "http://developer.apple.com/documentation/healthkit"
                 }
             ],
@@ -1684,6 +1923,49 @@
                 "hkunit": "dBASPL",
                 "system": "http://unitsofmeasure.org",
                 "unit": "dB(SPL)"
+            }
+        },
+        "HKQuantityTypeIdentifierEnvironmentalSoundReduction": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierEnvironmentalSoundReduction",
+                    "display": "Environmental Sound Reduction",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "dB(HL)",
+                "hkunit": "dBHL",
+                "system": "http://unitsofmeasure.org",
+                "unit": "dB(HL)"
+            }
+        },
+        "HKQuantityTypeIdentifierEstimatedWorkoutEffortScore": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierEstimatedWorkoutEffortScore",
+                    "display": "Workout Effort Score",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "count",
+                "unit": "effort"
+            }
+        },
+        "HKQuantityTypeIdentifierHeartRateRecoveryOneMinute": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierHeartRateRecoveryOneMinute",
+                    "display": "One-Minute Heart Rate Recovery",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "/min",
+                "hkunit": "count/min",
+                "system": "http://unitsofmeasure.org",
+                "unit": "beats/minute"
             }
         },
         "HKQuantityTypeIdentifierFlightsClimbed": {
@@ -1832,6 +2114,21 @@
                 "unit": "count"
             }
         },
+        "HKQuantityTypeIdentifierInsulinDelivery": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierInsulinDelivery",
+                    "display": "Insulin Delivery",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "IU",
+                "hkunit": "IU",
+                "system": "http://unitsofmeasure.org",
+                "unit": "IU"
+            }
+        },
         "HKQuantityTypeIdentifierLeanBodyMass": {
             "codings": [
                 {
@@ -1850,6 +2147,19 @@
                 "hkunit": "lb",
                 "system": "http://unitsofmeasure.org",
                 "unit": "lbs"
+            }
+        },
+        "HKQuantityTypeIdentifierNumberOfAlcoholicBeverages": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierNumberOfAlcoholicBeverages",
+                    "display": "Number of Alcoholic Beverages",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "count",
+                "unit": "beverages"
             }
         },
         "HKQuantityTypeIdentifierNumberOfTimesFallen": {
@@ -1883,6 +2193,21 @@
                 "hkunit": "%",
                 "system": "http://unitsofmeasure.org",
                 "unit": "%"
+            }
+        },
+        "HKQuantityTypeIdentifierPaddleSportsSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierPaddleSportsSpeed",
+                    "display": "Paddle Sports Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m/s",
+                "hkunit": "m/s",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m/s"
             }
         },
         "HKQuantityTypeIdentifierPeakExpiratoryFlowRate": {
@@ -1998,6 +2323,141 @@
                 "unit": "beats/minute"
             }
         },
+        "HKQuantityTypeIdentifierRowingSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierRowingSpeed",
+                    "display": "Rowing Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m/s",
+                "hkunit": "m/s",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m/s"
+            }
+        },
+        "HKQuantityTypeIdentifierRunningGroundContactTime": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierRunningGroundContactTime",
+                    "display": "Running Ground Contact Time",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "ms",
+                "hkunit": "ms",
+                "system": "http://unitsofmeasure.org",
+                "unit": "ms"
+            }
+        },
+        "HKQuantityTypeIdentifierRunningPower": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierRunningPower",
+                    "display": "Running Power",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "W",
+                "hkunit": "W",
+                "system": "http://unitsofmeasure.org",
+                "unit": "watt"
+            }
+        },
+        "HKQuantityTypeIdentifierRunningSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierRunningSpeed",
+                    "display": "Running Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "km/h",
+                "hkunit": "km/hr",
+                "system": "http://unitsofmeasure.org",
+                "unit": "km/h"
+            }
+        },
+        "HKQuantityTypeIdentifierRunningStrideLength": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierRunningStrideLength",
+                    "display": "Running Stride Length",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "meters"
+            }
+        },
+        "HKQuantityTypeIdentifierRunningVerticalOscillation": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierRunningVerticalOscillation",
+                    "display": "Running Vertical Oscillation",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
+            }
+        },
+        "HKQuantityTypeIdentifierSixMinuteWalkTestDistance": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierSixMinuteWalkTestDistance",
+                    "display": "Six Minute Walk Test Distance",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
+            }
+        },
+        "HKQuantityTypeIdentifierStairAscentSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierStairAscentSpeed",
+                    "display": "Stair Ascent Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m/s",
+                "hkunit": "m/s",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m/s"
+            }
+        },
+        "HKQuantityTypeIdentifierStairDescentSpeed": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierStairDescentSpeed",
+                    "display": "Stair Descent Speed",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m/s",
+                "hkunit": "m/s",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m/s"
+            }
+        },
         "HKQuantityTypeIdentifierStepCount": {
             "codings": [
                 {
@@ -2042,6 +2502,21 @@
                 "hkunit": "min",
                 "system": "http://unitsofmeasure.org",
                 "unit": "min"
+            }
+        },
+        "HKQuantityTypeIdentifierUnderwaterDepth": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierUnderwaterDepth",
+                    "display": "Underwater Depth",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
             }
         },
         "HKQuantityTypeIdentifierUVExposure": {
@@ -2107,6 +2582,21 @@
                 "unit": "%"
             }
         },
+        "HKQuantityTypeIdentifierWalkingDoubleSupportPercentage": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierWalkingDoubleSupportPercentage",
+                    "display": "Walking Double Support Percentage",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "%",
+                "hkunit": "%",
+                "system": "http://unitsofmeasure.org",
+                "unit": "%"
+            }
+        },
         "HKQuantityTypeIdentifierWalkingHeartRateAverage": {
             "codings": [
                 {
@@ -2135,6 +2625,49 @@
                 "hkunit": "m/s",
                 "system": "http://unitsofmeasure.org",
                 "unit": "m/s"
+            }
+        },
+        "HKQuantityTypeIdentifierWalkingStepLength": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierWalkingStepLength",
+                    "display": "Walking Step Length",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "m",
+                "hkunit": "m",
+                "system": "http://unitsofmeasure.org",
+                "unit": "m"
+            }
+        },
+        "HKQuantityTypeIdentifierWaterTemperature": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierWaterTemperature",
+                    "display": "Water Temperature",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "code": "Cel",
+                "hkunit": "degC",
+                "system": "http://unitsofmeasure.org",
+                "unit": "C"
+            }
+        },
+        "HKQuantityTypeIdentifierWorkoutEffortScore": {
+            "codings": [
+                {
+                    "code": "HKQuantityTypeIdentifierWorkoutEffortScore",
+                    "display": "Workout Effort Score",
+                    "system": "http://developer.apple.com/documentation/healthkit"
+                }
+            ],
+            "unit": {
+                "hkunit": "count",
+                "unit": "effort"
             }
         }
     }

--- a/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
+++ b/Tests/HealthKitOnFHIRTests/CustomMappingsTests.swift
@@ -12,6 +12,7 @@ import ModelsR4
 import Testing
 
 
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
 struct CustomMappingsTests {
     @Test
     func customMappings() throws {

--- a/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 
 // swiftlint:disable file_length type_body_length
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
 struct HKCategorySampleTests {
     var startDate: Date {
         get throws {

--- a/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
@@ -69,7 +69,7 @@ struct HKCategorySampleTests {
                 categoryType: .cervicalMucusQuality,
                 display: "Cervical Mucus Quality"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -86,7 +86,7 @@ struct HKCategorySampleTests {
                 categoryType: .menstrualFlow,
                 display: "Menstrual Flow"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -102,7 +102,7 @@ struct HKCategorySampleTests {
                 categoryType: .ovulationTestResult,
                 display: "Ovulation Test Result"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -118,7 +118,7 @@ struct HKCategorySampleTests {
                 categoryType: .contraceptive,
                 display: "Contraceptive"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -134,7 +134,7 @@ struct HKCategorySampleTests {
                 categoryType: .sleepAnalysis,
                 display: "Sleep Analysis"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -150,7 +150,7 @@ struct HKCategorySampleTests {
                 categoryType: .appetiteChanges,
                 display: "Appetite Changes"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -236,7 +236,7 @@ struct HKCategorySampleTests {
                 categoryType: .appleWalkingSteadinessEvent,
                 display: "Apple Walking Steadiness Event"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -309,7 +309,7 @@ struct HKCategorySampleTests {
                 categoryType: .pregnancyTestResult,
                 display: "Pregnancy Test Result"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
     
@@ -338,7 +338,7 @@ struct HKCategorySampleTests {
                 categoryType: .progesteroneTestResult,
                 display: "Progesterone Test Result"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
     
@@ -404,7 +404,7 @@ struct HKCategorySampleTests {
                 categoryType: .appleStandHour,
                 display: "Apple Stand Hour"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -552,7 +552,7 @@ struct HKCategorySampleTests {
                 categoryType: type,
                 display: display
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -678,7 +678,7 @@ struct HKCategorySampleTests {
                 categoryType: .moodChanges,
                 display: "Mood Changes"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -694,7 +694,7 @@ struct HKCategorySampleTests {
                 categoryType: .sleepChanges,
                 display: "Sleep Changes"
             ))
-            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
     
@@ -715,7 +715,7 @@ struct HKCategorySampleTests {
             categoryType: category,
             display: displayTitle
         ))
-        #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+        #expect(try observation.value == .string(value.fhirCategoryValue.asFHIRStringPrimitive()))
     }
 
     @Test

--- a/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
@@ -28,12 +28,12 @@ class HKCategorySampleTests: XCTestCase {
     }
 
     func createObservationFrom(
-        type categoryType: HKCategoryType,
+        type categoryType: HKCategoryTypeIdentifier,
         value: Int,
         metadata: [String: Any] = [:]
     ) throws -> Observation {
         let categorySample = HKCategorySample(
-            type: categoryType,
+            type: HKCategoryType(categoryType),
             value: value,
             start: try startDate,
             end: try endDate,
@@ -43,11 +43,11 @@ class HKCategorySampleTests: XCTestCase {
     }
 
     func createCategoryCoding(
-        categoryType: String,
+        categoryType: HKCategoryTypeIdentifier,
         display: String
     ) -> Coding {
         Coding(
-            code: FHIRPrimitive(stringLiteral: categoryType),
+            code: FHIRPrimitive(stringLiteral: categoryType.rawValue),
             display: FHIRPrimitive(stringLiteral: display),
             system: FHIRPrimitive(FHIRURI(stringLiteral: SupportedCodeSystem.apple.rawValue))
         )
@@ -58,18 +58,18 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.cervicalMucusQuality),
+                type: .cervicalMucusQuality,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.cervicalMucusQuality).description,
+                    categoryType: .cervicalMucusQuality,
                     display: "Cervical Mucus Quality"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -78,7 +78,7 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.menstrualFlow),
+                type: .menstrualFlow,
                 value: value.rawValue,
                 metadata: [HKMetadataKeyMenstrualCycleStart: true]
             )
@@ -86,10 +86,11 @@ class HKCategorySampleTests: XCTestCase {
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.menstrualFlow).description, display: "Menstrual Flow"
+                    categoryType: .menstrualFlow,
+                    display: "Menstrual Flow"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -98,19 +99,19 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.ovulationTestResult),
+                type: .ovulationTestResult,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.ovulationTestResult).description,
+                    categoryType: .ovulationTestResult,
                     display: "Ovulation Test Result"
                 )
             )
             XCTAssertEqual(
-                observation.value, .string(value.description.asFHIRStringPrimitive())
+                observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
             )
         }
     }
@@ -120,18 +121,18 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.contraceptive),
+                type: .contraceptive,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.contraceptive).description,
+                    categoryType: .contraceptive,
                     display: "Contraceptive"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -140,18 +141,18 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.sleepAnalysis),
+                type: .sleepAnalysis,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.sleepAnalysis).description,
+                    categoryType: .sleepAnalysis,
                     display: "Sleep Analysis"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -160,31 +161,31 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.appetiteChanges),
+                type: .appetiteChanges,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.appetiteChanges).description,
+                    categoryType: .appetiteChanges,
                     display: "Appetite Changes"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
     func testEnvironmentalAudioExposureEvent() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.environmentalAudioExposureEvent),
+            type: .environmentalAudioExposureEvent,
             value: HKCategoryValueEnvironmentalAudioExposureEvent.momentaryLimit.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.environmentalAudioExposureEvent).description,
+                categoryType: .environmentalAudioExposureEvent,
                 display: "Environmental Audio Exposure Event"
             )
         )
@@ -193,14 +194,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testHeadphoneAudioExposureEvent() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.headphoneAudioExposureEvent),
+            type: .headphoneAudioExposureEvent,
             value: HKCategoryValueHeadphoneAudioExposureEvent.sevenDayLimit.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.headphoneAudioExposureEvent).description,
+                categoryType: .headphoneAudioExposureEvent,
                 display: "Headphone Audio Exposure Event"
             )
         )
@@ -209,14 +210,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testLowCardioFitnessEvent() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.lowCardioFitnessEvent),
+            type: .lowCardioFitnessEvent,
             value: HKCategoryValueLowCardioFitnessEvent.lowFitness.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.lowCardioFitnessEvent).description,
+                categoryType: .lowCardioFitnessEvent,
                 display: "Low Cardio Fitness Event"
             )
         )
@@ -228,35 +229,35 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.appleWalkingSteadinessEvent),
+                type: .appleWalkingSteadinessEvent,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.appleWalkingSteadinessEvent).description,
+                    categoryType: .appleWalkingSteadinessEvent,
                     display: "Apple Walking Steadiness Event"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
     func testAppleWalkingSteadinessClassification() throws {
         let okClassification = try HKAppleWalkingSteadinessClassification(
             rawValue: HKAppleWalkingSteadinessClassification.ok.rawValue
-        )?.categoryValueDescription
+        )?.fhirCategoryValue
         XCTAssertEqual(okClassification, "ok")
 
         let lowClassification = try HKAppleWalkingSteadinessClassification(
             rawValue: HKAppleWalkingSteadinessClassification.low.rawValue
-        )?.categoryValueDescription
+        )?.fhirCategoryValue
         XCTAssertEqual(lowClassification, "low")
 
         let veryLowClassification = try HKAppleWalkingSteadinessClassification(
             rawValue: HKAppleWalkingSteadinessClassification.veryLow.rawValue
-        )?.categoryValueDescription
+        )?.fhirCategoryValue
         XCTAssertEqual(veryLowClassification, "very low")
     }
 
@@ -265,18 +266,18 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.pregnancyTestResult),
+                type: .pregnancyTestResult,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.pregnancyTestResult).description,
+                    categoryType: .pregnancyTestResult,
                     display: "Pregnancy Test Result"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -285,18 +286,18 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.progesteroneTestResult),
+                type: .progesteroneTestResult,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.progesteroneTestResult).description,
+                    categoryType: .progesteroneTestResult,
                     display: "Progesterone Test Result"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
@@ -305,31 +306,31 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.appleStandHour),
+                type: .appleStandHour,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.appleStandHour).description,
+                    categoryType: .appleStandHour,
                     display: "Apple Stand Hour"
                 )
             )
-            XCTAssertEqual(observation.value, .string(value.description.asFHIRStringPrimitive()))
+            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
     func testIntermenstrualBleeding() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.intermenstrualBleeding),
+            type: .intermenstrualBleeding,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.intermenstrualBleeding).description,
+                categoryType: .intermenstrualBleeding,
                 display: "Intermenstrual Bleeding"
             )
         )
@@ -341,14 +342,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testInfrequentMenstrualCycles() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.infrequentMenstrualCycles),
+            type: .infrequentMenstrualCycles,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.infrequentMenstrualCycles).description,
+                categoryType: .infrequentMenstrualCycles,
                 display: "Infrequent Menstrual Cycles"
             )
         )
@@ -360,14 +361,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testIrregularMenstrualCycles() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.irregularMenstrualCycles),
+            type: .irregularMenstrualCycles,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.irregularMenstrualCycles).description,
+                categoryType: .irregularMenstrualCycles,
                 display: "Irregular Menstrual Cycles"
             )
         )
@@ -379,14 +380,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testPersistentIntermenstrualBleeding() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.persistentIntermenstrualBleeding),
+            type: .persistentIntermenstrualBleeding,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.persistentIntermenstrualBleeding).description,
+                categoryType: .persistentIntermenstrualBleeding,
                 display: "Persistent Intermenstrual Bleeding"
             )
         )
@@ -398,14 +399,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testProlongedMenstrualPeriods() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.prolongedMenstrualPeriods),
+            type: .prolongedMenstrualPeriods,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.prolongedMenstrualPeriods).description,
+                categoryType: .prolongedMenstrualPeriods,
                 display: "Prolonged Menstrual Periods"
             )
         )
@@ -417,14 +418,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testLactation() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.lactation),
+            type: .lactation,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.lactation).description,
+                categoryType: .lactation,
                 display: "Lactation"
             )
         )
@@ -436,14 +437,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testHandwashingEvent() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.handwashingEvent),
+            type: .handwashingEvent,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.handwashingEvent).description,
+                categoryType: .handwashingEvent,
                 display: "Handwashing Event"
             )
         )
@@ -455,14 +456,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testToothbrushingEvent() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.toothbrushingEvent),
+            type: .toothbrushingEvent,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.toothbrushingEvent).description,
+                categoryType: .toothbrushingEvent,
                 display: "Toothbrushing Event"
             )
         )
@@ -474,14 +475,14 @@ class HKCategorySampleTests: XCTestCase {
 
     func testMindfulSession() throws {
         let observation = try createObservationFrom(
-            type: HKCategoryType(.mindfulSession),
+            type: .mindfulSession,
             value: HKCategoryValue.notApplicable.rawValue
         )
 
         XCTAssertEqual(
             observation.code.coding?.first,
             createCategoryCoding(
-                categoryType: HKCategoryType(.mindfulSession).description,
+                categoryType: .mindfulSession,
                 display: "Mindful Session"
             )
         )
@@ -493,7 +494,7 @@ class HKCategorySampleTests: XCTestCase {
 
     // SYMPTOM TESTS
 
-    func testSymptoms(type: HKCategoryType, display: String) throws {
+    func testSymptoms(type: HKCategoryTypeIdentifier, display: String) throws {
         let values: [HKCategoryValueSeverity] = [.moderate, .unspecified, .notPresent, .severe, .mild]
 
         for value in values {
@@ -505,104 +506,104 @@ class HKCategorySampleTests: XCTestCase {
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: type.description,
+                    categoryType: type,
                     display: display
                 )
             )
 
             XCTAssertEqual(
                 observation.value,
-                .string(value.description.asFHIRStringPrimitive())
+                .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
             )
         }
     }
 
     func testAbdominalCramps() throws {
-        try testSymptoms(type: HKCategoryType(.abdominalCramps), display: "Abdominal Cramps")
+        try testSymptoms(type: .abdominalCramps, display: "Abdominal Cramps")
     }
 
     func testAcne() throws {
-        try testSymptoms(type: HKCategoryType(.acne), display: "Acne")
+        try testSymptoms(type: .acne, display: "Acne")
     }
 
     func testBladderIncontinence() throws {
-        try testSymptoms(type: HKCategoryType(.bladderIncontinence), display: "Bladder Incontinence")
+        try testSymptoms(type: .bladderIncontinence, display: "Bladder Incontinence")
     }
 
     func testBloating() throws {
-        try testSymptoms(type: HKCategoryType(.bloating), display: "Bloating")
+        try testSymptoms(type: .bloating, display: "Bloating")
     }
 
     func testBreastPain() throws {
-        try testSymptoms(type: HKCategoryType(.breastPain), display: "Breast Pain")
+        try testSymptoms(type: .breastPain, display: "Breast Pain")
     }
 
     func testChestTightnessOrPain() throws {
-        try testSymptoms(type: HKCategoryType(.chestTightnessOrPain), display: "Chest Tightness Or Pain")
+        try testSymptoms(type: .chestTightnessOrPain, display: "Chest Tightness Or Pain")
     }
 
     func testChills() throws {
-        try testSymptoms(type: HKCategoryType(.chills), display: "Chills")
+        try testSymptoms(type: .chills, display: "Chills")
     }
 
     func testConstipation() throws {
-        try testSymptoms(type: HKCategoryType(.constipation), display: "Constipation")
+        try testSymptoms(type: .constipation, display: "Constipation")
     }
 
     func testCoughing() throws {
-        try testSymptoms(type: HKCategoryType(.coughing), display: "Coughing")
+        try testSymptoms(type: .coughing, display: "Coughing")
     }
 
     func testDizziness() throws {
-        try testSymptoms(type: HKCategoryType(.dizziness), display: "Dizziness")
+        try testSymptoms(type: .dizziness, display: "Dizziness")
     }
 
     func testDrySkin() throws {
-        try testSymptoms(type: HKCategoryType(.drySkin), display: "Dry Skin")
+        try testSymptoms(type: .drySkin, display: "Dry Skin")
     }
 
     func testFainting() throws {
-        try testSymptoms(type: HKCategoryType(.fainting), display: "Fainting")
+        try testSymptoms(type: .fainting, display: "Fainting")
     }
 
     func testFever() throws {
-        try testSymptoms(type: HKCategoryType(.fever), display: "Fever")
+        try testSymptoms(type: .fever, display: "Fever")
     }
 
     func testGeneralizedBodyAche() throws {
-        try testSymptoms(type: HKCategoryType(.generalizedBodyAche), display: "Generalized Body Ache")
+        try testSymptoms(type: .generalizedBodyAche, display: "Generalized Body Ache")
     }
 
     func testHairLoss() throws {
-        try testSymptoms(type: HKCategoryType(.hairLoss), display: "Hair Loss")
+        try testSymptoms(type: .hairLoss, display: "Hair Loss")
     }
 
     func testHeadache() throws {
-        try testSymptoms(type: HKCategoryType(.headache), display: "Headache")
+        try testSymptoms(type: .headache, display: "Headache")
     }
 
     func testHeartburn() throws {
-        try testSymptoms(type: HKCategoryType(.heartburn), display: "Heartburn")
+        try testSymptoms(type: .heartburn, display: "Heartburn")
     }
 
     func testHotFlashes() throws {
-        try testSymptoms(type: HKCategoryType(.hotFlashes), display: "Hot Flashes")
+        try testSymptoms(type: .hotFlashes, display: "Hot Flashes")
     }
 
     func testLossOfSmell() throws {
-        try testSymptoms(type: HKCategoryType(.lossOfSmell), display: "Loss Of Smell")
+        try testSymptoms(type: .lossOfSmell, display: "Loss Of Smell")
     }
 
     func testLossOfTaste() throws {
-        try testSymptoms(type: HKCategoryType(.lossOfTaste), display: "Loss Of Taste")
+        try testSymptoms(type: .lossOfTaste, display: "Loss Of Taste")
     }
 
     func testLowerBackPain() throws {
-        try testSymptoms(type: HKCategoryType(.lowerBackPain), display: "Lower Back Pain")
+        try testSymptoms(type: .lowerBackPain, display: "Lower Back Pain")
     }
 
     func testMemoryLapse() throws {
-        try testSymptoms(type: HKCategoryType(.memoryLapse), display: "Memory Lapse")
+        try testSymptoms(type: .memoryLapse, display: "Memory Lapse")
     }
 
     func testMoodChanges() throws {
@@ -610,21 +611,21 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.moodChanges),
+                type: .moodChanges,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.moodChanges).description,
+                    categoryType: .moodChanges,
                     display: "Mood Changes"
                 )
             )
 
             XCTAssertEqual(
                 observation.value,
-                .string(value.description.asFHIRStringPrimitive())
+                .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
             )
         }
     }
@@ -634,70 +635,70 @@ class HKCategorySampleTests: XCTestCase {
 
         for value in values {
             let observation = try createObservationFrom(
-                type: HKCategoryType(.sleepChanges),
+                type: .sleepChanges,
                 value: value.rawValue
             )
 
             XCTAssertEqual(
                 observation.code.coding?.first,
                 createCategoryCoding(
-                    categoryType: HKCategoryType(.sleepChanges).description,
+                    categoryType: .sleepChanges,
                     display: "Sleep Changes"
                 )
             )
 
             XCTAssertEqual(
                 observation.value,
-                .string(value.description.asFHIRStringPrimitive())
+                .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
             )
         }
     }
 
     func testNausea() throws {
-        try testSymptoms(type: HKCategoryType(.nausea), display: "Nausea")
+        try testSymptoms(type: .nausea, display: "Nausea")
     }
 
     func testNightSweats() throws {
-        try testSymptoms(type: HKCategoryType(.nightSweats), display: "Night Sweats")
+        try testSymptoms(type: .nightSweats, display: "Night Sweats")
     }
 
     func testPelvicPain() throws {
-        try testSymptoms(type: HKCategoryType(.pelvicPain), display: "Pelvic Pain")
+        try testSymptoms(type: .pelvicPain, display: "Pelvic Pain")
     }
 
     func testRapidPoundingOrFlutteringHeartbeat() throws {
-        try testSymptoms(type: HKCategoryType(.rapidPoundingOrFlutteringHeartbeat), display: "Rapid Pounding Or Fluttering Heartbeat")
+        try testSymptoms(type: .rapidPoundingOrFlutteringHeartbeat, display: "Rapid Pounding Or Fluttering Heartbeat")
     }
 
     func testRunnyNose() throws {
-        try testSymptoms(type: HKCategoryType(.runnyNose), display: "Runny Nose")
+        try testSymptoms(type: .runnyNose, display: "Runny Nose")
     }
 
     func testShortnessOfBreath() throws {
-        try testSymptoms(type: HKCategoryType(.shortnessOfBreath), display: "Shortness Of Breath")
+        try testSymptoms(type: .shortnessOfBreath, display: "Shortness Of Breath")
     }
 
     func testSinusCongestion() throws {
-        try testSymptoms(type: HKCategoryType(.sinusCongestion), display: "Sinus Congestion")
+        try testSymptoms(type: .sinusCongestion, display: "Sinus Congestion")
     }
 
     func testSkippedHeartbeat() throws {
-        try testSymptoms(type: HKCategoryType(.skippedHeartbeat), display: "Skipped Heartbeat")
+        try testSymptoms(type: .skippedHeartbeat, display: "Skipped Heartbeat")
     }
 
     func testSoreThroat() throws {
-        try testSymptoms(type: HKCategoryType(.soreThroat), display: "Sore Throat")
+        try testSymptoms(type: .soreThroat, display: "Sore Throat")
     }
 
     func testVaginalDryness() throws {
-        try testSymptoms(type: HKCategoryType(.vaginalDryness), display: "Vaginal Dryness")
+        try testSymptoms(type: .vaginalDryness, display: "Vaginal Dryness")
     }
 
     func testVomiting() throws {
-        try testSymptoms(type: HKCategoryType(.vomiting), display: "Vomiting")
+        try testSymptoms(type: .vomiting, display: "Vomiting")
     }
 
     func testWheezing() throws {
-        try testSymptoms(type: HKCategoryType(.wheezing), display: "Wheezing")
+        try testSymptoms(type: .wheezing, display: "Wheezing")
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCategorySampleTests.swift
@@ -9,24 +9,26 @@
 import HealthKit
 @testable import HealthKitOnFHIR
 import ModelsR4
-import XCTest
+import Testing
+
 
 // swiftlint:disable file_length type_body_length
-class HKCategorySampleTests: XCTestCase {
+struct HKCategorySampleTests {
     var startDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 0) // Date Stanford University opened (https://www.stanford.edu/about/history/)
-            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+            return try #require(Calendar.current.date(from: dateComponents))
         }
     }
 
     var endDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 42)
-            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+            return try #require(Calendar.current.date(from: dateComponents))
         }
     }
 
+    
     func createObservationFrom(
         type categoryType: HKCategoryTypeIdentifier,
         value: Int,
@@ -39,7 +41,7 @@ class HKCategorySampleTests: XCTestCase {
             end: try endDate,
             metadata: metadata
         )
-        return try XCTUnwrap(categorySample.resource().get(if: Observation.self))
+        return try #require(categorySample.resource().get(if: Observation.self))
     }
 
     func createCategoryCoding(
@@ -53,652 +55,737 @@ class HKCategorySampleTests: XCTestCase {
         )
     }
 
-    func testCervicalMucusQuality() throws {
+    
+    @Test
+    func cervicalMucusQuality() throws {
         let values: [HKCategoryValueCervicalMucusQuality] = [.dry, .sticky, .creamy, .watery, .eggWhite]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .cervicalMucusQuality,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .cervicalMucusQuality,
-                    display: "Cervical Mucus Quality"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .cervicalMucusQuality,
+                display: "Cervical Mucus Quality"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testMenstrualFlow() throws {
+    @Test
+    func menstrualFlow() throws {
         let values: [HKCategoryValueMenstrualFlow] = [.unspecified, .light, .medium, .heavy, .none]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .menstrualFlow,
                 value: value.rawValue,
                 metadata: [HKMetadataKeyMenstrualCycleStart: true]
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .menstrualFlow,
-                    display: "Menstrual Flow"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .menstrualFlow,
+                display: "Menstrual Flow"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testOvulationTestResult() throws {
+    @Test
+    func ovulationTestResult() throws {
         let values: [HKCategoryValueOvulationTestResult] = [.negative, .indeterminate, .luteinizingHormoneSurge, .estrogenSurge]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .ovulationTestResult,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .ovulationTestResult,
-                    display: "Ovulation Test Result"
-                )
-            )
-            XCTAssertEqual(
-                observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
-            )
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .ovulationTestResult,
+                display: "Ovulation Test Result"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testContraceptive() throws {
+    @Test
+    func contraceptive() throws {
         let values: [HKCategoryValueContraceptive] = [.unspecified, .implant, .injection, .intrauterineDevice, .intravaginalRing, .oral, .patch]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .contraceptive,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .contraceptive,
-                    display: "Contraceptive"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .contraceptive,
+                display: "Contraceptive"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testSleepAnalysis() throws {
+    @Test
+    func sleepAnalysis() throws {
         let values: [HKCategoryValueSleepAnalysis] = [.inBed, .asleepUnspecified, .awake, .asleepCore, .asleepDeep, .asleepREM]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .sleepAnalysis,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .sleepAnalysis,
-                    display: "Sleep Analysis"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .sleepAnalysis,
+                display: "Sleep Analysis"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testAppetiteChanges() throws {
+    @Test
+    func appetiteChanges() throws {
         let values: [HKCategoryValueAppetiteChanges] = [.unspecified, .noChange, .decreased, .increased]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .appetiteChanges,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .appetiteChanges,
-                    display: "Appetite Changes"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .appetiteChanges,
+                display: "Appetite Changes"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testEnvironmentalAudioExposureEvent() throws {
+    @Test
+    func environmentalAudioExposureEvent() throws {
         let observation = try createObservationFrom(
             type: .environmentalAudioExposureEvent,
             value: HKCategoryValueEnvironmentalAudioExposureEvent.momentaryLimit.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .environmentalAudioExposureEvent,
-                display: "Environmental Audio Exposure Event"
-            )
-        )
-        XCTAssertEqual(observation.value, .string("momentary limit".asFHIRStringPrimitive()))
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .environmentalAudioExposureEvent,
+            display: "Environmental Audio Exposure Event"
+        ))
+        #expect(observation.value == .string("momentary limit".asFHIRStringPrimitive()))
     }
 
-    func testHeadphoneAudioExposureEvent() throws {
+    @Test
+    func headphoneAudioExposureEvent() throws {
         let observation = try createObservationFrom(
             type: .headphoneAudioExposureEvent,
             value: HKCategoryValueHeadphoneAudioExposureEvent.sevenDayLimit.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .headphoneAudioExposureEvent,
-                display: "Headphone Audio Exposure Event"
-            )
-        )
-        XCTAssertEqual(observation.value, .string("seven day limit".asFHIRStringPrimitive()))
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .headphoneAudioExposureEvent,
+            display: "Headphone Audio Exposure Event"
+        ))
+        #expect(observation.value == .string("seven day limit".asFHIRStringPrimitive()))
     }
 
-    func testLowCardioFitnessEvent() throws {
+    @Test
+    func lowCardioFitnessEvent() throws {
         let observation = try createObservationFrom(
             type: .lowCardioFitnessEvent,
             value: HKCategoryValueLowCardioFitnessEvent.lowFitness.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .lowCardioFitnessEvent,
-                display: "Low Cardio Fitness Event"
-            )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .lowCardioFitnessEvent,
+            display: "Low Cardio Fitness Event"
+        ))
+        #expect(observation.value == .string("low fitness".asFHIRStringPrimitive()))
+    }
+    
+    @Test
+    func lowCardioFitnessEventWithMetadata() throws {
+        let observation = try createObservationFrom(
+            type: .lowCardioFitnessEvent,
+            value: HKCategoryValueLowCardioFitnessEvent.lowFitness.rawValue,
+            metadata: [
+                HKMetadataKeyLowCardioFitnessEventThreshold: HKQuantity(unit: HKUnit(from: "ml/(kg*min)"), doubleValue: 41)
+            ]
         )
-        XCTAssertEqual(observation.value, .string("low fitness".asFHIRStringPrimitive()))
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .lowCardioFitnessEvent,
+            display: "Low Cardio Fitness Event"
+        ))
+        #expect(observation.value == .string("low fitness".asFHIRStringPrimitive()))
+        #expect(observation.component?.count == 1)
+        let component = try #require(observation.component?.first)
+        #expect(component.code.coding == [
+            Coding(
+                code: "HKQuantityTypeIdentifierVO2Max".asFHIRStringPrimitive(),
+                display: "VO2 Max".asFHIRStringPrimitive(),
+                system: SupportedCodeSystem.apple.rawValue.asFHIRURIPrimitive()
+            )
+        ])
+        #expect(component.value == .quantity(Quantity(
+            code: "mL/kg/min",
+            system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+            unit: "mL/kg/min",
+            value: 41.asFHIRDecimalPrimitive()
+        )))
     }
 
-    func testAppleWalkingSteadinessEvent() throws {
+    @Test
+    func appleWalkingSteadinessEvent() throws {
         let values: [HKCategoryValueAppleWalkingSteadinessEvent] = [.initialLow, .initialVeryLow, .repeatLow, .repeatVeryLow]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .appleWalkingSteadinessEvent,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .appleWalkingSteadinessEvent,
-                    display: "Apple Walking Steadiness Event"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .appleWalkingSteadinessEvent,
+                display: "Apple Walking Steadiness Event"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testAppleWalkingSteadinessClassification() throws {
+    @Test
+    func appleWalkingSteadinessClassification() throws {
         let okClassification = try HKAppleWalkingSteadinessClassification(
             rawValue: HKAppleWalkingSteadinessClassification.ok.rawValue
         )?.fhirCategoryValue
-        XCTAssertEqual(okClassification, "ok")
+        #expect(okClassification == "ok")
 
         let lowClassification = try HKAppleWalkingSteadinessClassification(
             rawValue: HKAppleWalkingSteadinessClassification.low.rawValue
         )?.fhirCategoryValue
-        XCTAssertEqual(lowClassification, "low")
+        #expect(lowClassification == "low")
 
         let veryLowClassification = try HKAppleWalkingSteadinessClassification(
             rawValue: HKAppleWalkingSteadinessClassification.veryLow.rawValue
         )?.fhirCategoryValue
-        XCTAssertEqual(veryLowClassification, "very low")
+        #expect(veryLowClassification == "very low")
+    }
+    
+    @Test(arguments: [
+        (HKCategoryTypeIdentifier.lowHeartRateEvent, "Low Heart Rate Event"),
+        (HKCategoryTypeIdentifier.highHeartRateEvent, "High Heart Rate Event")
+    ])
+    func lowHeartRateEvent(category: HKCategoryTypeIdentifier, displayTitle: String) throws {
+        let observation = try createObservationFrom(
+            type: category,
+            value: HKCategoryValue.notApplicable.rawValue,
+            metadata: [
+                HKMetadataKeyHeartRateEventThreshold: HKQuantity(unit: HKUnit(from: "count/min"), doubleValue: 47)
+            ]
+        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: category,
+            display: displayTitle
+        ))
+        #expect(observation.value == .string(category.rawValue.asFHIRStringPrimitive()))
+        #expect(observation.component?.count == 1)
+        let component = try #require(observation.component?.first)
+        #expect(component.code.coding == [
+            Coding(
+                code: "8867-4".asFHIRStringPrimitive(),
+                display: "Heart rate".asFHIRStringPrimitive(),
+                system: SupportedCodeSystem.loinc.rawValue.asFHIRURIPrimitive()
+            ),
+            Coding(
+                code: "HKQuantityTypeIdentifierHeartRate".asFHIRStringPrimitive(),
+                display: "Heart Rate".asFHIRStringPrimitive(),
+                system: SupportedCodeSystem.apple.rawValue.asFHIRURIPrimitive()
+            )
+        ])
+        #expect(component.value == .quantity(Quantity(
+            code: "/min",
+            system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+            unit: "beats/minute",
+            value: 47.asFHIRDecimalPrimitive()
+        )))
     }
 
-    func testPregnancyTestResult() throws {
+    @Test
+    func pregnancyTestResult() throws {
         let values: [HKCategoryValuePregnancyTestResult] = [.negative, .positive, .indeterminate]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .pregnancyTestResult,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .pregnancyTestResult,
-                    display: "Pregnancy Test Result"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .pregnancyTestResult,
+                display: "Pregnancy Test Result"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
+    
+    @Test
+    func pregnancy() throws {
+        let observation = try createObservationFrom(
+            type: .pregnancy,
+            value: HKCategoryValue.notApplicable.rawValue
+        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .pregnancy,
+            display: "Pregnancy"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierPregnancy".asFHIRStringPrimitive()))
+    }
 
-    func testProgesteroneTestResult() throws {
+    @Test
+    func progesteroneTestResult() throws {
         let values: [HKCategoryValueProgesteroneTestResult] = [.indeterminate, .positive, .negative]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .progesteroneTestResult,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .progesteroneTestResult,
-                    display: "Progesterone Test Result"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .progesteroneTestResult,
+                display: "Progesterone Test Result"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
+    
+    @Test
+    func sexualActivityNoMetadata() throws {
+        let observation = try createObservationFrom(
+            type: .sexualActivity,
+            value: HKCategoryValue.notApplicable.rawValue
+        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .sexualActivity,
+            display: "Sexual Activity"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierSexualActivity".asFHIRStringPrimitive()))
+        #expect(observation.component == nil)
+    }
+    
+    @Test
+    func sexualActivityWithMetadata1() throws {
+        let observation = try createObservationFrom(
+            type: .sexualActivity,
+            value: HKCategoryValue.notApplicable.rawValue,
+            metadata: [
+                HKMetadataKeySexualActivityProtectionUsed: true
+            ]
+        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .sexualActivity,
+            display: "Sexual Activity"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierSexualActivity".asFHIRStringPrimitive()))
+        #expect(observation.component?.count == 1)
+        #expect(observation.component?.first?.value == .boolean(true))
+    }
+    
+    @Test
+    func sexualActivityWithMetadata2() throws {
+        let observation = try createObservationFrom(
+            type: .sexualActivity,
+            value: HKCategoryValue.notApplicable.rawValue,
+            metadata: [
+                HKMetadataKeySexualActivityProtectionUsed: false
+            ]
+        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .sexualActivity,
+            display: "Sexual Activity"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierSexualActivity".asFHIRStringPrimitive()))
+        #expect(observation.component?.count == 1)
+        #expect(observation.component?.first?.value == .boolean(false))
+    }
 
-    func testAppleStandHour() throws {
+    @Test
+    func appleStandHour() throws {
         let values: [HKCategoryValueAppleStandHour] = [.stood, .idle]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .appleStandHour,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .appleStandHour,
-                    display: "Apple Stand Hour"
-                )
-            )
-            XCTAssertEqual(observation.value, .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .appleStandHour,
+                display: "Apple Stand Hour"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testIntermenstrualBleeding() throws {
+    @Test
+    func intermenstrualBleeding() throws {
         let observation = try createObservationFrom(
             type: .intermenstrualBleeding,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .intermenstrualBleeding,
-                display: "Intermenstrual Bleeding"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierIntermenstrualBleeding".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .intermenstrualBleeding,
+            display: "Intermenstrual Bleeding"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierIntermenstrualBleeding".asFHIRStringPrimitive()))
     }
 
-    func testInfrequentMenstrualCycles() throws {
+    @Test
+    func infrequentMenstrualCycles() throws {
         let observation = try createObservationFrom(
             type: .infrequentMenstrualCycles,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .infrequentMenstrualCycles,
-                display: "Infrequent Menstrual Cycles"
-            )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .infrequentMenstrualCycles,
+            display: "Infrequent Menstrual Cycles"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierInfrequentMenstrualCycles".asFHIRStringPrimitive()))
+    }
+    
+    @Test
+    func irregularHeartRhythmEvent() throws {
+        let observation = try createObservationFrom(
+            type: .irregularHeartRhythmEvent,
+            value: HKCategoryValue.notApplicable.rawValue
         )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierInfrequentMenstrualCycles".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .irregularHeartRhythmEvent,
+            display: "Irregular Heart Rhythm Event"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierIrregularHeartRhythmEvent".asFHIRStringPrimitive()))
     }
 
-    func testIrregularMenstrualCycles() throws {
+    @Test
+    func irregularMenstrualCycles() throws {
         let observation = try createObservationFrom(
             type: .irregularMenstrualCycles,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .irregularMenstrualCycles,
-                display: "Irregular Menstrual Cycles"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierIrregularMenstrualCycles".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .irregularMenstrualCycles,
+            display: "Irregular Menstrual Cycles"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierIrregularMenstrualCycles".asFHIRStringPrimitive()))
     }
 
-    func testPersistentIntermenstrualBleeding() throws {
+    @Test
+    func persistentIntermenstrualBleeding() throws {
         let observation = try createObservationFrom(
             type: .persistentIntermenstrualBleeding,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .persistentIntermenstrualBleeding,
-                display: "Persistent Intermenstrual Bleeding"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierPersistentIntermenstrualBleeding".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .persistentIntermenstrualBleeding,
+            display: "Persistent Intermenstrual Bleeding"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierPersistentIntermenstrualBleeding".asFHIRStringPrimitive()))
     }
 
-    func testProlongedMenstrualPeriods() throws {
+    @Test
+    func prolongedMenstrualPeriods() throws {
         let observation = try createObservationFrom(
             type: .prolongedMenstrualPeriods,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .prolongedMenstrualPeriods,
-                display: "Prolonged Menstrual Periods"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierProlongedMenstrualPeriods".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .prolongedMenstrualPeriods,
+            display: "Prolonged Menstrual Periods"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierProlongedMenstrualPeriods".asFHIRStringPrimitive()))
     }
 
-    func testLactation() throws {
+    @Test
+    func lactation() throws {
         let observation = try createObservationFrom(
             type: .lactation,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .lactation,
-                display: "Lactation"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierLactation".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .lactation,
+            display: "Lactation"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierLactation".asFHIRStringPrimitive()))
     }
 
-    func testHandwashingEvent() throws {
+    @Test
+    func handwashingEvent() throws {
         let observation = try createObservationFrom(
             type: .handwashingEvent,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .handwashingEvent,
-                display: "Handwashing Event"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierHandwashingEvent".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .handwashingEvent,
+            display: "Handwashing Event"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierHandwashingEvent".asFHIRStringPrimitive()))
     }
 
-    func testToothbrushingEvent() throws {
+    @Test
+    func toothbrushingEvent() throws {
         let observation = try createObservationFrom(
             type: .toothbrushingEvent,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .toothbrushingEvent,
-                display: "Toothbrushing Event"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierToothbrushingEvent".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .toothbrushingEvent,
+            display: "Toothbrushing Event"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierToothbrushingEvent".asFHIRStringPrimitive()))
     }
 
-    func testMindfulSession() throws {
+    @Test
+    func mindfulSession() throws {
         let observation = try createObservationFrom(
             type: .mindfulSession,
             value: HKCategoryValue.notApplicable.rawValue
         )
-
-        XCTAssertEqual(
-            observation.code.coding?.first,
-            createCategoryCoding(
-                categoryType: .mindfulSession,
-                display: "Mindful Session"
-            )
-        )
-        XCTAssertEqual(
-            observation.value,
-            .string("HKCategoryTypeIdentifierMindfulSession".asFHIRStringPrimitive())
-        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: .mindfulSession,
+            display: "Mindful Session"
+        ))
+        #expect(observation.value == .string("HKCategoryTypeIdentifierMindfulSession".asFHIRStringPrimitive()))
     }
 
-    // SYMPTOM TESTS
+    
+    // MARK: Symptom Tests
 
     func testSymptoms(type: HKCategoryTypeIdentifier, display: String) throws {
         let values: [HKCategoryValueSeverity] = [.moderate, .unspecified, .notPresent, .severe, .mild]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: type,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: type,
-                    display: display
-                )
-            )
-
-            XCTAssertEqual(
-                observation.value,
-                .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
-            )
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: type,
+                display: display
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testAbdominalCramps() throws {
+    @Test
+    func abdominalCramps() throws {
         try testSymptoms(type: .abdominalCramps, display: "Abdominal Cramps")
     }
 
-    func testAcne() throws {
+    @Test
+    func acne() throws {
         try testSymptoms(type: .acne, display: "Acne")
     }
 
-    func testBladderIncontinence() throws {
+    @Test
+    func bladderIncontinence() throws {
         try testSymptoms(type: .bladderIncontinence, display: "Bladder Incontinence")
     }
 
-    func testBloating() throws {
+    @Test
+    func bloating() throws {
         try testSymptoms(type: .bloating, display: "Bloating")
     }
 
-    func testBreastPain() throws {
+    @Test
+    func breastPain() throws {
         try testSymptoms(type: .breastPain, display: "Breast Pain")
     }
 
-    func testChestTightnessOrPain() throws {
+    @Test
+    func chestTightnessOrPain() throws {
         try testSymptoms(type: .chestTightnessOrPain, display: "Chest Tightness Or Pain")
     }
 
-    func testChills() throws {
+    @Test
+    func chills() throws {
         try testSymptoms(type: .chills, display: "Chills")
     }
 
-    func testConstipation() throws {
+    @Test
+    func constipation() throws {
         try testSymptoms(type: .constipation, display: "Constipation")
     }
 
-    func testCoughing() throws {
+    @Test
+    func coughing() throws {
         try testSymptoms(type: .coughing, display: "Coughing")
     }
 
-    func testDizziness() throws {
+    @Test
+    func dizziness() throws {
         try testSymptoms(type: .dizziness, display: "Dizziness")
     }
 
-    func testDrySkin() throws {
+    @Test
+    func drySkin() throws {
         try testSymptoms(type: .drySkin, display: "Dry Skin")
     }
 
-    func testFainting() throws {
+    @Test
+    func fainting() throws {
         try testSymptoms(type: .fainting, display: "Fainting")
     }
 
-    func testFever() throws {
+    @Test
+    func fever() throws {
         try testSymptoms(type: .fever, display: "Fever")
     }
 
-    func testGeneralizedBodyAche() throws {
+    @Test
+    func generalizedBodyAche() throws {
         try testSymptoms(type: .generalizedBodyAche, display: "Generalized Body Ache")
     }
 
-    func testHairLoss() throws {
+    @Test
+    func hairLoss() throws {
         try testSymptoms(type: .hairLoss, display: "Hair Loss")
     }
 
-    func testHeadache() throws {
+    @Test
+    func headache() throws {
         try testSymptoms(type: .headache, display: "Headache")
     }
 
-    func testHeartburn() throws {
+    @Test
+    func heartburn() throws {
         try testSymptoms(type: .heartburn, display: "Heartburn")
     }
 
-    func testHotFlashes() throws {
+    @Test
+    func hotFlashes() throws {
         try testSymptoms(type: .hotFlashes, display: "Hot Flashes")
     }
 
-    func testLossOfSmell() throws {
+    @Test
+    func lossOfSmell() throws {
         try testSymptoms(type: .lossOfSmell, display: "Loss Of Smell")
     }
 
-    func testLossOfTaste() throws {
+    @Test
+    func lossOfTaste() throws {
         try testSymptoms(type: .lossOfTaste, display: "Loss Of Taste")
     }
 
-    func testLowerBackPain() throws {
+    @Test
+    func lowerBackPain() throws {
         try testSymptoms(type: .lowerBackPain, display: "Lower Back Pain")
     }
 
-    func testMemoryLapse() throws {
+    @Test
+    func memoryLapse() throws {
         try testSymptoms(type: .memoryLapse, display: "Memory Lapse")
     }
 
-    func testMoodChanges() throws {
+    @Test
+    func moodChanges() throws {
         let values: [HKCategoryValuePresence] = [.notPresent, .present]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .moodChanges,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .moodChanges,
-                    display: "Mood Changes"
-                )
-            )
-
-            XCTAssertEqual(
-                observation.value,
-                .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
-            )
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .moodChanges,
+                display: "Mood Changes"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
 
-    func testSleepChanges() throws {
+    @Test
+    func sleepChanges() throws {
         let values: [HKCategoryValuePresence] = [.notPresent, .present]
-
         for value in values {
             let observation = try createObservationFrom(
                 type: .sleepChanges,
                 value: value.rawValue
             )
-
-            XCTAssertEqual(
-                observation.code.coding?.first,
-                createCategoryCoding(
-                    categoryType: .sleepChanges,
-                    display: "Sleep Changes"
-                )
-            )
-
-            XCTAssertEqual(
-                observation.value,
-                .string(try value.fhirCategoryValue.asFHIRStringPrimitive())
-            )
+            #expect(observation.code.coding?.first == createCategoryCoding(
+                categoryType: .sleepChanges,
+                display: "Sleep Changes"
+            ))
+            #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
         }
     }
+    
+    @Test(arguments: product([
+        (HKCategoryTypeIdentifier.bleedingDuringPregnancy, "Bleeding During Pregnancy"),
+        (HKCategoryTypeIdentifier.bleedingAfterPregnancy, "Bleeding After Pregnancy")
+    ], [
+        HKCategoryValueVaginalBleeding.none, .light, .medium, .heavy
+    ]))
+    @available(iOS 18.0, watchOS 11.0, macOS 15.0, visionOS 2.0, *)
+    func pregnancyBleeding(categoryInput: (HKCategoryTypeIdentifier, String), value: HKCategoryValueVaginalBleeding) throws {
+        let (category, displayTitle) = categoryInput
+        let observation = try createObservationFrom(
+            type: category,
+            value: value.rawValue
+        )
+        #expect(observation.code.coding?.first == createCategoryCoding(
+            categoryType: category,
+            display: displayTitle
+        ))
+        #expect(observation.value == .string(try value.fhirCategoryValue.asFHIRStringPrimitive()))
+    }
 
-    func testNausea() throws {
+    @Test
+    func nausea() throws {
         try testSymptoms(type: .nausea, display: "Nausea")
     }
 
-    func testNightSweats() throws {
+    @Test
+    func nightSweats() throws {
         try testSymptoms(type: .nightSweats, display: "Night Sweats")
     }
 
-    func testPelvicPain() throws {
+    @Test
+    func pelvicPain() throws {
         try testSymptoms(type: .pelvicPain, display: "Pelvic Pain")
     }
 
-    func testRapidPoundingOrFlutteringHeartbeat() throws {
+    @Test
+    func rapidPoundingOrFlutteringHeartbeat() throws {
         try testSymptoms(type: .rapidPoundingOrFlutteringHeartbeat, display: "Rapid Pounding Or Fluttering Heartbeat")
     }
 
-    func testRunnyNose() throws {
+    @Test
+    func runnyNose() throws {
         try testSymptoms(type: .runnyNose, display: "Runny Nose")
     }
 
-    func testShortnessOfBreath() throws {
+    @Test
+    func shortnessOfBreath() throws {
         try testSymptoms(type: .shortnessOfBreath, display: "Shortness Of Breath")
     }
 
-    func testSinusCongestion() throws {
+    @Test
+    func sinusCongestion() throws {
         try testSymptoms(type: .sinusCongestion, display: "Sinus Congestion")
     }
 
-    func testSkippedHeartbeat() throws {
+    @Test
+    func skippedHeartbeat() throws {
         try testSymptoms(type: .skippedHeartbeat, display: "Skipped Heartbeat")
     }
 
-    func testSoreThroat() throws {
+    @Test
+    func soreThroat() throws {
         try testSymptoms(type: .soreThroat, display: "Sore Throat")
     }
 
-    func testVaginalDryness() throws {
+    @Test
+    func vaginalDryness() throws {
         try testSymptoms(type: .vaginalDryness, display: "Vaginal Dryness")
     }
 
-    func testVomiting() throws {
+    @Test
+    func vomiting() throws {
         try testSymptoms(type: .vomiting, display: "Vomiting")
     }
 
-    func testWheezing() throws {
+    @Test
+    func wheezing() throws {
         try testSymptoms(type: .wheezing, display: "Wheezing")
+    }
+}
+
+
+func product<C1: Collection, C2: Collection>(
+    _ first: C1,
+    _ second: C2
+) -> some Collection<(C1.Element, C2.Element)> & Sendable where C1: Sendable, C2: Sendable, C1.Element: Sendable, C2.Element: Sendable {
+    first.lazy.flatMap { element1 in
+        second.lazy.map { element2 in
+            (element1, element2)
+        }
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
@@ -75,6 +75,7 @@ class HKCorrelationTests: XCTestCase {
     }
 
     func testUnsupportedCorrelation() throws {
+        throw XCTSkip()
         // Food correlations are not currently supported
         let vitaminC = HKQuantitySample(
             type: HKQuantityType(.dietaryVitaminC),

--- a/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
@@ -12,6 +12,7 @@ import ModelsR4
 import Testing
 
 
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
 struct HKCorrelationTests {
     var startDate: Date {
         get throws {

--- a/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKCorrelationTests.swift
@@ -9,25 +9,26 @@
 import HealthKit
 @testable import HealthKitOnFHIR
 import ModelsR4
-import XCTest
+import Testing
 
 
-class HKCorrelationTests: XCTestCase {
+struct HKCorrelationTests {
     var startDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 0) // Date Stanford University opened (https://www.stanford.edu/about/history/)
-            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+            return try #require(Calendar.current.date(from: dateComponents))
         }
     }
 
     var endDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 42)
-            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+            return try #require(Calendar.current.date(from: dateComponents))
         }
     }
 
-    func testBloodPressureCorrelation() throws {
+    @Test
+    func bloodPressureCorrelation() throws {
         let systolicBloodPressure = HKQuantitySample(
             type: HKQuantityType(.bloodPressureSystolic),
             quantity: HKQuantity(unit: .millimeterOfMercury(), doubleValue: 120),
@@ -49,9 +50,9 @@ class HKCorrelationTests: XCTestCase {
             objects: [systolicBloodPressure, diastolicBloodPressure]
         )
         
-        let observation = try XCTUnwrap(correlation.resource().get(if: Observation.self))
+        let observation = try #require(correlation.resource().get(if: Observation.self))
 
-        XCTAssertEqual(1, observation.component?.filter {
+        #expect(1 == observation.component?.filter {
             $0.value == .quantity(
                 Quantity(
                     code: "mm[Hg]",
@@ -62,7 +63,7 @@ class HKCorrelationTests: XCTestCase {
             )
         }.count)
 
-        XCTAssertEqual(1, observation.component?.filter {
+        #expect(1 == observation.component?.filter {
             $0.value == .quantity(
                 Quantity(
                     code: "mm[Hg]",
@@ -74,8 +75,8 @@ class HKCorrelationTests: XCTestCase {
         }.count)
     }
 
-    func testUnsupportedCorrelation() throws {
-        throw XCTSkip()
+    @Test(.disabled())
+    func unsupportedCorrelation() throws {
         // Food correlations are not currently supported
         let vitaminC = HKQuantitySample(
             type: HKQuantityType(.dietaryVitaminC),
@@ -90,6 +91,8 @@ class HKCorrelationTests: XCTestCase {
             end: try endDate,
             objects: [vitaminC]
         )
-        XCTAssertThrowsError(try correlation.resource())
+        #expect(throws: HealthKitOnFHIRError.self) {
+            try correlation.resource()
+        }
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKElectrocardiogramTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKElectrocardiogramTests.swift
@@ -8,22 +8,24 @@
 
 import HealthKit
 @testable import HealthKitOnFHIR
-import XCTest
+import Testing
 
 
-class HKElectrocardiogramTests: XCTestCase {
-    func testElectrocardiogramCategoryTests() throws {
-        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.notSet.fhirCategoryValue, "notSet")
-        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.none.fhirCategoryValue, "none")
-        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.present.fhirCategoryValue, "present")
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
+struct HKElectrocardiogramTests {
+    @Test
+    func electrocardiogramCategoryTests() throws {
+        #expect(try HKElectrocardiogram.SymptomsStatus.notSet.fhirCategoryValue == "notSet")
+        #expect(try HKElectrocardiogram.SymptomsStatus.none.fhirCategoryValue == "none")
+        #expect(try HKElectrocardiogram.SymptomsStatus.present.fhirCategoryValue == "present")
         
-        try XCTAssertEqual(HKElectrocardiogram.Classification.notSet.fhirCategoryValue, "notSet")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.sinusRhythm.fhirCategoryValue, "sinusRhythm")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.atrialFibrillation.fhirCategoryValue, "atrialFibrillation")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveLowHeartRate.fhirCategoryValue, "inconclusiveLowHeartRate")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveHighHeartRate.fhirCategoryValue, "inconclusiveHighHeartRate")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusivePoorReading.fhirCategoryValue, "inconclusivePoorReading")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveOther.fhirCategoryValue, "inconclusiveOther")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.unrecognized.fhirCategoryValue, "unrecognized")
+        #expect(try HKElectrocardiogram.Classification.notSet.fhirCategoryValue == "notSet")
+        #expect(try HKElectrocardiogram.Classification.sinusRhythm.fhirCategoryValue == "sinusRhythm")
+        #expect(try HKElectrocardiogram.Classification.atrialFibrillation.fhirCategoryValue == "atrialFibrillation")
+        #expect(try HKElectrocardiogram.Classification.inconclusiveLowHeartRate.fhirCategoryValue == "inconclusiveLowHeartRate")
+        #expect(try HKElectrocardiogram.Classification.inconclusiveHighHeartRate.fhirCategoryValue == "inconclusiveHighHeartRate")
+        #expect(try HKElectrocardiogram.Classification.inconclusivePoorReading.fhirCategoryValue == "inconclusivePoorReading")
+        #expect(try HKElectrocardiogram.Classification.inconclusiveOther.fhirCategoryValue == "inconclusiveOther")
+        #expect(try HKElectrocardiogram.Classification.unrecognized.fhirCategoryValue == "unrecognized")
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKElectrocardiogramTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKElectrocardiogramTests.swift
@@ -13,17 +13,17 @@ import XCTest
 
 class HKElectrocardiogramTests: XCTestCase {
     func testElectrocardiogramCategoryTests() throws {
-        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.notSet.categoryValueDescription, "notSet")
-        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.none.categoryValueDescription, "none")
-        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.present.categoryValueDescription, "present")
+        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.notSet.fhirCategoryValue, "notSet")
+        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.none.fhirCategoryValue, "none")
+        try XCTAssertEqual(HKElectrocardiogram.SymptomsStatus.present.fhirCategoryValue, "present")
         
-        try XCTAssertEqual(HKElectrocardiogram.Classification.notSet.categoryValueDescription, "notSet")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.sinusRhythm.categoryValueDescription, "sinusRhythm")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.atrialFibrillation.categoryValueDescription, "atrialFibrillation")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveLowHeartRate.categoryValueDescription, "inconclusiveLowHeartRate")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveHighHeartRate.categoryValueDescription, "inconclusiveHighHeartRate")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusivePoorReading.categoryValueDescription, "inconclusivePoorReading")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveOther.categoryValueDescription, "inconclusiveOther")
-        try XCTAssertEqual(HKElectrocardiogram.Classification.unrecognized.categoryValueDescription, "unrecognized")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.notSet.fhirCategoryValue, "notSet")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.sinusRhythm.fhirCategoryValue, "sinusRhythm")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.atrialFibrillation.fhirCategoryValue, "atrialFibrillation")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveLowHeartRate.fhirCategoryValue, "inconclusiveLowHeartRate")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveHighHeartRate.fhirCategoryValue, "inconclusiveHighHeartRate")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusivePoorReading.fhirCategoryValue, "inconclusivePoorReading")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.inconclusiveOther.fhirCategoryValue, "inconclusiveOther")
+        try XCTAssertEqual(HKElectrocardiogram.Classification.unrecognized.fhirCategoryValue, "unrecognized")
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -11,8 +11,10 @@ import HealthKit
 import ModelsR4
 import XCTest
 
+
 // swiftlint:disable file_length
 // We disable the file length rule as this is a test class
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
 class HKQuantitySampleTests: XCTestCase {
     // swiftlint:disable:previous type_body_length
     // We disable the type body length as this is a test class

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -9,26 +9,26 @@
 import HealthKit
 @testable import HealthKitOnFHIR
 import ModelsR4
-import XCTest
+import Testing
 
 
 // swiftlint:disable file_length
 // We disable the file length rule as this is a test class
 @MainActor // to work around https://github.com/apple/FHIRModels/issues/36
-class HKQuantitySampleTests: XCTestCase {
+struct HKQuantitySampleTests {
     // swiftlint:disable:previous type_body_length
     // We disable the type body length as this is a test class
     var startDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 0) // Date Stanford University opened (https://www.stanford.edu/about/history/)
-            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+            return try #require(Calendar.current.date(from: dateComponents))
         }
     }
     
     var endDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 42)
-            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+            return try #require(Calendar.current.date(from: dateComponents))
         }
     }
     
@@ -44,7 +44,7 @@ class HKQuantitySampleTests: XCTestCase {
             end: try endDate,
             metadata: metadata
         )
-        return try XCTUnwrap(quantitySample.resource().get(if: Observation.self))
+        return try #require(quantitySample.resource().get(if: Observation.self))
     }
     
     func createCoding(
@@ -59,1184 +59,911 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
-    func testBloodGlucose() throws {
+    @Test
+    func bloodGlucose() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.bloodGlucose),
             quantity: HKQuantity(unit: HKUnit(from: "mg/dL"), doubleValue: 99)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "41653-7",
-                    display: "Glucose Glucometer (BldC) [Mass/Vol]",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBloodGlucose",
-                    display: "Blood Glucose",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg/dL",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg/dL",
-                    value: 99.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "41653-7",
+                display: "Glucose Glucometer (BldC) [Mass/Vol]",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierBloodGlucose",
+                display: "Blood Glucose",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg/dL",
+                system: "http://unitsofmeasure.org",
+                unit: "mg/dL",
+                value: 99.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryBiotin() throws {
+    @Test
+    func dietaryBiotin() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryBiotin),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryBiotin",
-                    display: "Dietary Biotin",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryBiotin",
+                display: "Dietary Biotin",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryCaffeine() throws {
+    @Test
+    func dietaryCaffeine() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryCaffeine),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryCaffeine",
-                    display: "Dietary Caffeine",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryCaffeine",
+                display: "Dietary Caffeine",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryCalcium() throws {
+    @Test
+    func dietaryCalcium() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryCalcium),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 1000)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryCalcium",
-                    display: "Dietary Calcium",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 1000.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryCalcium",
+                display: "Dietary Calcium",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 1000.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryCarbohydrates() throws {
+    @Test
+    func dietaryCarbohydrates() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryCarbohydrates),
             quantity: HKQuantity(unit: .gram(), doubleValue: 1000)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryCarbohydates",
-                    display: "Dietary Carbohydates",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 1000.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryCarbohydates",
+                display: "Dietary Carbohydates",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 1000.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryChloride() throws {
+    @Test
+    func dietaryChloride() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryChloride),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 2300)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryChloride",
-                    display: "Dietary Chloride",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 2300.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryChloride",
+                display: "Dietary Chloride",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 2300.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryCholesterol() throws {
+    @Test
+    func dietaryCholesterol() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryCholesterol),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryCholesterol",
-                    display: "Dietary Cholesterol",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryCholesterol",
+                display: "Dietary Cholesterol",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryChromium() throws {
+    @Test
+    func dietaryChromium() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryChromium),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 25)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryChromium",
-                    display: "Dietary Chromium",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 25.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryChromium",
+                display: "Dietary Chromium",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 25.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryCopper() throws {
+    @Test
+    func dietaryCopper() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryCopper),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 900)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryCopper",
-                    display: "Dietary Copper",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 900.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryCopper",
+                display: "Dietary Copper",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 900.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryFatMonounsaturated() throws {
+    @Test
+    func dietaryFatMonounsaturated() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryFatMonounsaturated),
             quantity: HKQuantity(unit: .gram(), doubleValue: 22)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryFatMonounsaturated",
-                    display: "Dietary Fat Monounsaturated",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 22.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryFatMonounsaturated",
+                display: "Dietary Fat Monounsaturated",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 22.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryFatPolyunsaturated() throws {
+    @Test
+    func dietaryFatPolyunsaturated() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryFatPolyunsaturated),
             quantity: HKQuantity(unit: .gram(), doubleValue: 30)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryFatPolyunsaturated",
-                    display: "Dietary Fat Polyunsaturated",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 30.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryFatPolyunsaturated",
+                display: "Dietary Fat Polyunsaturated",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 30.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryFatSaturated() throws {
+    @Test
+    func dietaryFatSaturated() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryFatSaturated),
             quantity: HKQuantity(unit: .gram(), doubleValue: 30)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryFatSaturated",
-                    display: "Dietary Fat Saturated",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 30.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryFatSaturated",
+                display: "Dietary Fat Saturated",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 30.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryFatTotal() throws {
+    @Test
+    func dietaryFatTotal() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryFatTotal),
             quantity: HKQuantity(unit: .gram(), doubleValue: 66)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryFatTotal",
-                    display: "Dietary Fat Total",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 66.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryFatTotal",
+                display: "Dietary Fat Total",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 66.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryFiber() throws {
+    @Test
+    func dietaryFiber() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryFiber),
             quantity: HKQuantity(unit: .gram(), doubleValue: 30)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "LP203183-1",
-                    display: "Fiber intake",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryFiber",
-                    display: "Dietary Fiber",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 30.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "LP203183-1",
+                display: "Fiber intake",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryFiber",
+                display: "Dietary Fiber",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 30.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryFolate() throws {
+    @Test
+    func dietaryFolate() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryFolate),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 400)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryFolate",
-                    display: "Dietary Folate",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 400.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryFolate",
+                display: "Dietary Folate",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 400.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryIodine() throws {
+    @Test
+    func dietaryIodine() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryIodine),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 140)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryIodine",
-                    display: "Dietary Iodine",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 140.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryIodine",
+                display: "Dietary Iodine",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 140.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryIron() throws {
+    @Test
+    func dietaryIron() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryIron),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 16)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryIron",
-                    display: "Dietary Iron",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 16.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryIron",
+                display: "Dietary Iron",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 16.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryMagnesium() throws {
+    @Test
+    func dietaryMagnesium() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryMagnesium),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 400)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryMagnesium",
-                    display: "Dietary Magnesium",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 400.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryMagnesium",
+                display: "Dietary Magnesium",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 400.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryManganese() throws {
+    @Test
+    func dietaryManganese() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryManganese),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 2.3)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryManganese",
-                    display: "Dietary Manganese",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 2.3.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryManganese",
+                display: "Dietary Manganese",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 2.3.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryMolybdenum() throws {
+    @Test
+    func dietaryMolybdenum() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryMolybdenum),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 45)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryMolybdenum",
-                    display: "Dietary Molybdenum",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 45.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryMolybdenum",
+                display: "Dietary Molybdenum",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 45.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryPhosphorus() throws {
+    @Test
+    func dietaryPhosphorus() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryPhosphorus),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 1000)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryPhosphorus",
-                    display: "Dietary Phosphorus",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 1000.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryPhosphorus",
+                display: "Dietary Phosphorus",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 1000.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryPotassium() throws {
+    @Test
+    func dietaryPotassium() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryPotassium),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 1000)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryPotassium",
-                    display: "Dietary Potassium",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 1000.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryPotassium",
+                display: "Dietary Potassium",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 1000.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietarySodium() throws {
+    @Test
+    func dietarySodium() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietarySodium),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 1000)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietarySodium",
-                    display: "Dietary Sodium",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 1000.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietarySodium",
+                display: "Dietary Sodium",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 1000.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryNiacin() throws {
+    @Test
+    func dietaryNiacin() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryNiacin),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 16)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryNiacin",
-                    display: "Dietary Niacin",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 16.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryNiacin",
+                display: "Dietary Niacin",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 16.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryPantothenicAcid() throws {
+    @Test
+    func dietaryPantothenicAcid() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryPantothenicAcid),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryPantothenicAcid",
-                    display: "Dietary Pantothenic Acid",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryPantothenicAcid",
+                display: "Dietary Pantothenic Acid",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryProtein() throws {
+    @Test
+    func dietaryProtein() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryProtein),
             quantity: HKQuantity(unit: .gram(), doubleValue: 40)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryProtein",
-                    display: "Dietary Protein",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 40.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryProtein",
+                display: "Dietary Protein",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 40.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryRiboflavin() throws {
+    @Test
+    func dietaryRiboflavin() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryRiboflavin),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 1.3)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryRiboflavin",
-                    display: "Dietary Riboflavin",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 1.3.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryRiboflavin",
+                display: "Dietary Riboflavin",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 1.3.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietarySelenium() throws {
+    @Test
+    func dietarySelenium() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietarySelenium),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 55)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietarySelenium",
-                    display: "Dietary Selenium",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 55.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietarySelenium",
+                display: "Dietary Selenium",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 55.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietarySugar() throws {
+    @Test
+    func dietarySugar() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietarySugar),
             quantity: HKQuantity(unit: .gram(), doubleValue: 30)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietarySugar",
-                    display: "Dietary Sugar",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "g",
-                    system: "http://unitsofmeasure.org",
-                    unit: "g",
-                    value: 30.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietarySugar",
+                display: "Dietary Sugar",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "g",
+                system: "http://unitsofmeasure.org",
+                unit: "g",
+                value: 30.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryThiamin() throws {
+    @Test
+    func dietaryThiamin() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryThiamin),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 1.2)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryThiamin",
-                    display: "Dietary Thiamin",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 1.2.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryThiamin",
+                display: "Dietary Thiamin",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 1.2.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryVitaminA() throws {
+    @Test
+    func dietaryVitaminA() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryVitaminA),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 900)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryVitaminA",
-                    display: "Dietary Vitamin A",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 900.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryVitaminA",
+                display: "Dietary Vitamin A",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 900.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryVitaminB12() throws {
+    @Test
+    func dietaryVitaminB12() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryVitaminB12),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 2.4)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryVitaminB12",
-                    display: "Dietary Vitamin B12",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 2.4.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryVitaminB12",
+                display: "Dietary Vitamin B12",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 2.4.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryVitaminB6() throws {
+    @Test
+    func dietaryVitaminB6() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryVitaminB6),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 1.5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryVitaminB6",
-                    display: "Dietary Vitamin B6",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 1.5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryVitaminB6",
+                display: "Dietary Vitamin B6",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 1.5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryVitaminC() throws {
+    @Test
+    func dietaryVitaminC() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryVitaminC),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 90)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryVitaminC",
-                    display: "Dietary Vitamin C",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 90.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryVitaminC",
+                display: "Dietary Vitamin C",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 90.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryVitaminD() throws {
+    @Test
+    func dietaryVitaminD() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryVitaminD),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 20)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryVitaminD",
-                    display: "Dietary Vitamin D",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 20.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryVitaminD",
+                display: "Dietary Vitamin D",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 20.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryVitaminE() throws {
+    @Test
+    func dietaryVitaminE() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryVitaminE),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 15)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryVitaminE",
-                    display: "Dietary Vitamin E",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 15.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryVitaminE",
+                display: "Dietary Vitamin E",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 15.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryVitaminK() throws {
+    @Test
+    func dietaryVitaminK() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryVitaminK),
             quantity: HKQuantity(unit: .gramUnit(with: .micro), doubleValue: 15)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryVitaminK",
-                    display: "Dietary Vitamin K",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ug",
-                    system: "http://unitsofmeasure.org",
-                    unit: "ug",
-                    value: 15.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryVitaminK",
+                display: "Dietary Vitamin K",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ug",
+                system: "http://unitsofmeasure.org",
+                unit: "ug",
+                value: 15.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryWater() throws {
+    @Test
+    func dietaryWater() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryWater),
             quantity: HKQuantity(unit: .liter(), doubleValue: 2)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryWater",
-                    display: "Dietary Water",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "l",
-                    system: "http://unitsofmeasure.org",
-                    unit: "l",
-                    value: 2.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryWater",
+                display: "Dietary Water",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "l",
+                system: "http://unitsofmeasure.org",
+                unit: "l",
+                value: 2.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
-    func testDietaryZinc() throws {
+    @Test
+    func dietaryZinc() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.dietaryZinc),
             quantity: HKQuantity(unit: .gramUnit(with: .milli), doubleValue: 11)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDietaryZinc",
-                    display: "Dietary Zinc",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mg",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mg",
-                    value: 11.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDietaryZinc",
+                display: "Dietary Zinc",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mg",
+                system: "http://unitsofmeasure.org",
+                unit: "mg",
+                value: 11.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testElectrodermalActivity() throws {
@@ -1244,29 +971,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.electrodermalActivity),
             quantity: HKQuantity(unit: .siemen(), doubleValue: 0.000001)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierElectrodermalActivity",
-                    display: "Electrodermal Activity",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "S",
-                    system: "http://unitsofmeasure.org",
-                    unit: "siemens",
-                    value: 0.000001.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierElectrodermalActivity",
+                display: "Electrodermal Activity",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "S",
+                system: "http://unitsofmeasure.org",
+                unit: "siemens",
+                value: 0.000001.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testForcedExpiratoryVolume1() throws {
@@ -1274,34 +993,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.forcedExpiratoryVolume1),
             quantity: HKQuantity(unit: .liter(), doubleValue: 3.5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "20150-9",
-                    display: "FEV1",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierForcedExpiratoryVolume1",
-                    display: "Forced Expiratory Volume 1",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "L",
-                    system: "http://unitsofmeasure.org",
-                    unit: "L",
-                    value: 3.5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "20150-9",
+                display: "FEV1",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierForcedExpiratoryVolume1",
+                display: "Forced Expiratory Volume 1",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "L",
+                system: "http://unitsofmeasure.org",
+                unit: "L",
+                value: 3.5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testForcedVitalCapacity() throws {
@@ -1309,34 +1020,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.forcedVitalCapacity),
             quantity: HKQuantity(unit: .liter(), doubleValue: 5.5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "19870-5",
-                    display: "Forced vital capacity [Volume] Respiratory system",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierForcedVitalCapacity",
-                    display: "Forced Vital Capacity",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "L",
-                    system: "http://unitsofmeasure.org",
-                    unit: "L",
-                    value: 5.5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "19870-5",
+                display: "Forced vital capacity [Volume] Respiratory system",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierForcedVitalCapacity",
+                display: "Forced Vital Capacity",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "L",
+                system: "http://unitsofmeasure.org",
+                unit: "L",
+                value: 5.5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testInhalerUsage() throws {
@@ -1344,60 +1047,44 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.inhalerUsage),
             quantity: HKQuantity(unit: .count(), doubleValue: 3)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierInhalerUsage",
-                    display: "Inhaler Usage",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    unit: "count",
-                    value: 3.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierInhalerUsage",
+                display: "Inhaler Usage",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                unit: "count",
+                value: 3.asFHIRDecimalPrimitive()
+            )
+        ))
     }
-    
+
     func testStepCount() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.stepCount),
             quantity: HKQuantity(unit: .count(), doubleValue: 42)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "55423-8",
-                    display: "Number of steps in unspecified time Pedometer",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierStepCount",
-                    display: "Step Count",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    unit: "steps",
-                    value: 42.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "55423-8",
+                display: "Number of steps in unspecified time Pedometer",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierStepCount",
+                display: "Step Count",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                unit: "steps",
+                value: 42.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testFlightsClimbed() throws {
@@ -1405,32 +1092,24 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.flightsClimbed),
             quantity: HKQuantity(unit: .count(), doubleValue: 10)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "100304-5",
-                    display: "Flights climbed [#] Reporting Period",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierFlightsClimbed",
-                    display: "Flights Climbed",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    unit: "flights",
-                    value: 10.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "100304-5",
+                display: "Flights climbed [#] Reporting Period",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierFlightsClimbed",
+                display: "Flights Climbed",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                unit: "flights",
+                value: 10.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testHeartRate() throws {
@@ -1438,34 +1117,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.heartRate),
             quantity: HKQuantity(unit: .count().unitDivided(by: .minute()), doubleValue: 84)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "8867-4",
-                    display: "Heart rate",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierHeartRate",
-                    display: "Heart Rate",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "/min",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "beats/minute",
-                    value: 84.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "8867-4",
+                display: "Heart rate",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierHeartRate",
+                display: "Heart Rate",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "/min",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "beats/minute",
+                value: 84.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testRestingHeartRate() throws {
@@ -1473,34 +1144,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.restingHeartRate),
             quantity: HKQuantity(unit: .count().unitDivided(by: .minute()), doubleValue: 84)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "40443-4",
-                    display: "Heart rate --resting",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierRestingHeartRate",
-                    display: "Resting Heart Rate",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "/min",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "beats/minute",
-                    value: 84.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "40443-4",
+                display: "Heart rate --resting",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierRestingHeartRate",
+                display: "Resting Heart Rate",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "/min",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "beats/minute",
+                value: 84.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testWalkingHeartRateAverage() throws {
@@ -1508,29 +1171,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.walkingHeartRateAverage),
             quantity: HKQuantity(unit: .count().unitDivided(by: .minute()), doubleValue: 84)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierWalkingHeartRateAverage",
-                    display: "Walking Heart Rate Average",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "/min",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "beats/minute",
-                    value: 84.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierWalkingHeartRateAverage",
+                display: "Walking Heart Rate Average",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "/min",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "beats/minute",
+                value: 84.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testWalkingAsymmetryPercentage() throws {
@@ -1538,29 +1193,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.walkingAsymmetryPercentage),
             quantity: HKQuantity(unit: .percent(), doubleValue: 50)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierWalkingAsymmetryPercentage",
-                    display: "Walking Asymmetry Percentage",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "%",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "%",
-                    value: 50.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierWalkingAsymmetryPercentage",
+                display: "Walking Asymmetry Percentage",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "%",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "%",
+                value: 50.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testWalkingSpeed() throws {
@@ -1568,29 +1215,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.walkingSpeed),
             quantity: HKQuantity(unit: HKUnit.meter().unitDivided(by: HKUnit.second()), doubleValue: 1.5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierWalkingSpeed",
-                    display: "Walking Speed",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "m/s",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "m/s",
-                    value: 1.5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierWalkingSpeed",
+                display: "Walking Speed",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "m/s",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "m/s",
+                value: 1.5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testHeartRateVariabilitySDNN() throws {
@@ -1598,34 +1237,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.heartRateVariabilitySDNN),
             quantity: HKQuantity(unit: .secondUnit(with: .milli), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "80404-7",
-                    display: "R-R interval.standard deviation (Heart rate variability)",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierHeartRateVariabilitySDNN",
-                    display: "Heart Rate Variability SDNN",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "ms",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "ms",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "80404-7",
+                display: "R-R interval.standard deviation (Heart rate variability)",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierHeartRateVariabilitySDNN",
+                display: "Heart Rate Variability SDNN",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "ms",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "ms",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testOxygenSaturation() throws {
@@ -1633,34 +1264,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.oxygenSaturation),
             quantity: HKQuantity(unit: .percent(), doubleValue: 99)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "59408-5",
-                    display: "Oxygen saturation in Arterial blood by Pulse oximetry",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierOxygenSaturation",
-                    display: "Oxygen Saturation",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "%",
-                    system: "http://unitsofmeasure.org",
-                    unit: "%",
-                    value: 99.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "59408-5",
+                display: "Oxygen saturation in Arterial blood by Pulse oximetry",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierOxygenSaturation",
+                display: "Oxygen Saturation",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "%",
+                system: "http://unitsofmeasure.org",
+                unit: "%",
+                value: 99.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testPeakExpiratoryFlowRate() throws {
@@ -1668,34 +1291,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.peakExpiratoryFlowRate),
             quantity: HKQuantity(unit: .liter().unitDivided(by: .minute()), doubleValue: 600)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "19935-6",
-                    display: "Maximum expiratory gas flow Respiratory system airway by Peak flow meter",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierPeakExpiratoryFlowRate",
-                    display: "Peak Expiratory Flow Rate",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "L/min",
-                    system: "http://unitsofmeasure.org",
-                    unit: "L/min",
-                    value: 600.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "19935-6",
+                display: "Maximum expiratory gas flow Respiratory system airway by Peak flow meter",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierPeakExpiratoryFlowRate",
+                display: "Peak Expiratory Flow Rate",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "L/min",
+                system: "http://unitsofmeasure.org",
+                unit: "L/min",
+                value: 600.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testPeripheralPerfusionIndex() throws {
@@ -1703,34 +1318,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.peripheralPerfusionIndex),
             quantity: HKQuantity(unit: .percent(), doubleValue: 5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "61006-3",
-                    display: "Perfusion index Tissue by Pulse oximetry",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierPeripheralPerfusionIndex",
-                    display: "Peripheral Perfusion Index",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "%",
-                    system: "http://unitsofmeasure.org",
-                    unit: "%",
-                    value: 5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "61006-3",
+                display: "Perfusion index Tissue by Pulse oximetry",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierPeripheralPerfusionIndex",
+                display: "Peripheral Perfusion Index",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "%",
+                system: "http://unitsofmeasure.org",
+                unit: "%",
+                value: 5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testPushCount() throws {
@@ -1738,32 +1345,24 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.pushCount),
             quantity: HKQuantity(unit: .count(), doubleValue: 5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "96502-0",
-                    display: "Number of wheelchair pushes per time period",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierPushCount",
-                    display: "Push Count",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    unit: "wheelchair pushes",
-                    value: 5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "96502-0",
+                display: "Number of wheelchair pushes per time period",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierPushCount",
+                display: "Push Count",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                unit: "wheelchair pushes",
+                value: 5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
@@ -1772,29 +1371,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.timeInDaylight),
             quantity: HKQuantity(unit: .minute(), doubleValue: 100)
         )
-            
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierTimeInDaylight",
-                    display: "Time in Daylight",
-                    system: .apple
-                )
-            ]
-        )
-            
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "min",
-                    system: "http://unitsofmeasure.org",
-                    unit: "min",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierTimeInDaylight",
+                display: "Time in Daylight",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "min",
+                system: "http://unitsofmeasure.org",
+                unit: "min",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testUVExposure() throws {
@@ -1802,57 +1393,41 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.uvExposure),
             quantity: HKQuantity(unit: .count(), doubleValue: 5)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierUVExposure",
-                    display: "UV Exposure",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    unit: "count",
-                    value: 5.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierUVExposure",
+                display: "UV Exposure",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                unit: "count",
+                value: 5.asFHIRDecimalPrimitive()
+            )
+        ))
     }
-    
+
     func testVO2Max() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.vo2Max),
             quantity: HKQuantity(unit: HKUnit(from: "mL/kg*min"), doubleValue: 31)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierVO2Max",
-                    display: "VO2 Max",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "mL/kg/min",
-                    system: "http://unitsofmeasure.org",
-                    unit: "mL/kg/min",
-                    value: 31.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierVO2Max",
+                display: "VO2 Max",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "mL/kg/min",
+                system: "http://unitsofmeasure.org",
+                unit: "mL/kg/min",
+                value: 31.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testWaistCircumference() throws {
@@ -1860,34 +1435,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.waistCircumference),
             quantity: HKQuantity(unit: HKUnit(from: "in"), doubleValue: 38.7)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "8280-0",
-                    display: "Waist Circumference at umbilicus by Tape measure",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierWaistCircumference",
-                    display: "Waist Circumference",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "in",
-                    system: "http://unitsofmeasure.org",
-                    unit: "in",
-                    value: 38.7.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "8280-0",
+                display: "Waist Circumference at umbilicus by Tape measure",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierWaistCircumference",
+                display: "Waist Circumference",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "in",
+                system: "http://unitsofmeasure.org",
+                unit: "in",
+                value: 38.7.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testBodyTemperature() throws {
@@ -1895,34 +1462,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.bodyTemperature),
             quantity: HKQuantity(unit: .degreeCelsius(), doubleValue: 37)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "8310-5",
-                    display: "Body temperature",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBodyTemperature",
-                    display: "Body Temperature",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "Cel",
-                    system: "http://unitsofmeasure.org",
-                    unit: "C",
-                    value: 37.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "8310-5",
+                display: "Body temperature",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierBodyTemperature",
+                display: "Body Temperature",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "Cel",
+                system: "http://unitsofmeasure.org",
+                unit: "C",
+                value: 37.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testBasalBodyTemperature() throws {
@@ -1930,29 +1489,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.basalBodyTemperature),
             quantity: HKQuantity(unit: .degreeCelsius(), doubleValue: 37)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBasalBodyTemperature",
-                    display: "Basal Body Temperature",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "Cel",
-                    system: "http://unitsofmeasure.org",
-                    unit: "C",
-                    value: 37.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierBasalBodyTemperature",
+                display: "Basal Body Temperature",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "Cel",
+                system: "http://unitsofmeasure.org",
+                unit: "C",
+                value: 37.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testBasalEnergyBurned() throws {
@@ -1960,29 +1511,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.basalEnergyBurned),
             quantity: HKQuantity(unit: HKUnit(from: "kcal"), doubleValue: 1200)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBasalEnergyBurned",
-                    display: "Basal energy burned",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "kcal",
-                    system: "http://unitsofmeasure.org",
-                    unit: "kcal",
-                    value: 1200.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierBasalEnergyBurned",
+                display: "Basal energy burned",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "kcal",
+                system: "http://unitsofmeasure.org",
+                unit: "kcal",
+                value: 1200.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testBloodAlcoholContent() throws {
@@ -1990,34 +1533,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.bloodAlcoholContent),
             quantity: HKQuantity(unit: .percent(), doubleValue: 0.0)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "74859-0",
-                    display: "Ethanol [Mass/volume] in Blood Estimated from serum or plasma level",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBloodAlcoholContent",
-                    display: "Blood Alcohol Content",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "%",
-                    system: "http://unitsofmeasure.org",
-                    unit: "%",
-                    value: 0.0.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "74859-0",
+                display: "Ethanol [Mass/volume] in Blood Estimated from serum or plasma level",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierBloodAlcoholContent",
+                display: "Blood Alcohol Content",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "%",
+                system: "http://unitsofmeasure.org",
+                unit: "%",
+                value: 0.0.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testBodyFatPercentage() throws {
@@ -2025,34 +1560,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.bodyFatPercentage),
             quantity: HKQuantity(unit: .percent(), doubleValue: 21)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "41982-0",
-                    display: "Percentage of body fat Measured",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBodyFatPercentage",
-                    display: "Body Fat Percentage",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "%",
-                    system: "http://unitsofmeasure.org",
-                    unit: "%",
-                    value: 21.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "41982-0",
+                display: "Percentage of body fat Measured",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierBodyFatPercentage",
+                display: "Body Fat Percentage",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "%",
+                system: "http://unitsofmeasure.org",
+                unit: "%",
+                value: 21.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testBodyMassIndex() throws {
@@ -2060,34 +1587,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.bodyMassIndex),
             quantity: HKQuantity(unit: .count(), doubleValue: 20)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "39156-5",
-                    display: "Body mass index (BMI) [Ratio]",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBodyMassIndex",
-                    display: "Body Mass Index",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "kg/m2",
-                    system: "http://unitsofmeasure.org",
-                    unit: "kg/m^2",
-                    value: 20.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "39156-5",
+                display: "Body mass index (BMI) [Ratio]",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierBodyMassIndex",
+                display: "Body Mass Index",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "kg/m2",
+                system: "http://unitsofmeasure.org",
+                unit: "kg/m^2",
+                value: 20.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testHeight() throws {
@@ -2095,34 +1614,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.height),
             quantity: HKQuantity(unit: .inch(), doubleValue: 64)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "8302-2",
-                    display: "Body height",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierHeight",
-                    display: "Height",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "[in_i]",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "in",
-                    value: 64.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "8302-2",
+                display: "Body height",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierHeight",
+                display: "Height",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "[in_i]",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "in",
+                value: 64.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testBodyMass() throws {
@@ -2130,34 +1641,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.bodyMass),
             quantity: HKQuantity(unit: .pound(), doubleValue: 60)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "29463-7",
-                    display: "Body weight",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierBodyMass",
-                    display: "Body Mass",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "[lb_av]",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "lbs",
-                    value: 60.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "29463-7",
+                display: "Body weight",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierBodyMass",
+                display: "Body Mass",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "[lb_av]",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "lbs",
+                value: 60.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testLeanBodyMass() throws {
@@ -2165,34 +1668,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.leanBodyMass),
             quantity: HKQuantity(unit: .pound(), doubleValue: 60)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "91557-9",
-                    display: "Lean body weight",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierLeanBodyMass",
-                    display: "Lean Body Mass",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "[lb_av]",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "lbs",
-                    value: 60.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "91557-9",
+                display: "Lean body weight",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierLeanBodyMass",
+                display: "Lean Body Mass",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "[lb_av]",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "lbs",
+                value: 60.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testNumberOfTimesFallen() throws {
@@ -2200,90 +1695,66 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.numberOfTimesFallen),
             quantity: HKQuantity(unit: .count(), doubleValue: 0)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierNumberOfTimesFallen",
-                    display: "Number Of Times Fallen",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    unit: "falls",
-                    value: 0.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierNumberOfTimesFallen",
+                display: "Number Of Times Fallen",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                unit: "falls",
+                value: 0.asFHIRDecimalPrimitive()
+            )
+        ))
     }
-    
+
     func testSwimmingStrokeCount() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.swimmingStrokeCount),
             quantity: HKQuantity(unit: .count(), doubleValue: 10)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierSwimmingStrokeCount",
-                    display: "Swimming Stroke Count",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    unit: "strokes",
-                    value: 10.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierSwimmingStrokeCount",
+                display: "Swimming Stroke Count",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                unit: "strokes",
+                value: 10.asFHIRDecimalPrimitive()
+            )
+        ))
     }
-    
+
     func testRespiratoryRate() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.respiratoryRate),
             quantity: HKQuantity(unit: .count().unitDivided(by: .minute()), doubleValue: 18)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "9279-1",
-                    display: "Respiratory rate",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierRespiratoryRate",
-                    display: "Respiratory Rate",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "/min",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "breaths/minute",
-                    value: 18.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "9279-1",
+                display: "Respiratory rate",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierRespiratoryRate",
+                display: "Respiratory Rate",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "/min",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "breaths/minute",
+                value: 18.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testActiveEnergyBurned() throws {
@@ -2291,34 +1762,26 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.activeEnergyBurned),
             quantity: HKQuantity(unit: .largeCalorie(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "41981-2",
-                    display: "Calories burned",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierActiveEnergyBurned",
-                    display: "Active Energy Burned",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "kcal",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "kcal",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "41981-2",
+                display: "Calories burned",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierActiveEnergyBurned",
+                display: "Active Energy Burned",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "kcal",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "kcal",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testAppleExerciseTime() throws {
@@ -2326,29 +1789,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.appleExerciseTime),
             quantity: HKQuantity(unit: .minute(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierAppleExerciseTime",
-                    display: "Apple Exercise Time",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "min",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "min",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierAppleExerciseTime",
+                display: "Apple Exercise Time",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "min",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "min",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testAppleMoveTime() throws {
@@ -2356,29 +1811,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.appleMoveTime),
             quantity: HKQuantity(unit: .minute(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierAppleMoveTime",
-                    display: "Apple Move Time",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "min",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "min",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierAppleMoveTime",
+                display: "Apple Move Time",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "min",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "min",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
@@ -2387,29 +1834,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.physicalEffort),
             quantity: HKQuantity(unit: HKUnit(from: "kcal/hr*kg"), doubleValue: 2)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierPhysicalEffort",
-                    display: "Apple Physical Effort",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "kcal/hr/kg",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "kcal/hr/kg",
-                    value: 2.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierPhysicalEffort",
+                display: "Apple Physical Effort",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "kcal/hr/kg",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "kcal/hr/kg",
+                value: 2.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testAppleStandTime() throws {
@@ -2417,29 +1856,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.appleStandTime),
             quantity: HKQuantity(unit: .minute(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierAppleStandTime",
-                    display: "Apple Stand Time",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "min",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "min",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierAppleStandTime",
+                display: "Apple Stand Time",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "min",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "min",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testAppleWalkingSteadiness() throws {
@@ -2447,29 +1878,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.appleWalkingSteadiness),
             quantity: HKQuantity(unit: .percent(), doubleValue: 50)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierAppleWalkingSteadiness",
-                    display: "Apple Walking Steadiness",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "%",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "%",
-                    value: 50.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierAppleWalkingSteadiness",
+                display: "Apple Walking Steadiness",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "%",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "%",
+                value: 50.asFHIRDecimalPrimitive()
+            )
+        ))
     }
 
     func testDistanceCycling() throws {
@@ -2477,29 +1900,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.distanceCycling),
             quantity: HKQuantity(unit: .meter(), doubleValue: 1000)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDistanceCycling",
-                    display: "Distance Cycling",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "m",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "m",
-                    value: 1000.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDistanceCycling",
+                display: "Distance Cycling",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "m",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "m",
+                value: 1000.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testDistanceDownhillSnowSports() throws {
@@ -2507,29 +1922,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.distanceDownhillSnowSports),
             quantity: HKQuantity(unit: .meter(), doubleValue: 1000)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDistanceDownhillSnowSports",
-                    display: "Distance Downhill Snow Sports",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "m",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "m",
-                    value: 1000.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDistanceDownhillSnowSports",
+                display: "Distance Downhill Snow Sports",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "m",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "m",
+                value: 1000.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testDistanceSwimming() throws {
@@ -2537,64 +1944,49 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.distanceSwimming),
             quantity: HKQuantity(unit: .meter(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "93816-7",
-                    display: "Swimming distance unspecified time",
-                    system: .loinc
-                ),
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDistanceSwimming",
-                    display: "Distance Swimming",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "m",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "m",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "93816-7",
+                display: "Swimming distance unspecified time",
+                system: .loinc
+            ),
+            createCoding(
+                code: "HKQuantityTypeIdentifierDistanceSwimming",
+                display: "Distance Swimming",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "m",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "m",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
+
     
     func testDistanceWalkingRunning() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.distanceWalkingRunning),
             quantity: HKQuantity(unit: .meter(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDistanceWalkingRunning",
-                    display: "Distance Walking or Running",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "m",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "m",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDistanceWalkingRunning",
+                display: "Distance Walking or Running",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "m",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "m",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testDistanceWheelchair() throws {
@@ -2602,29 +1994,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.distanceWheelchair),
             quantity: HKQuantity(unit: .meter(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierDistanceWheelchair",
-                    display: "Distance in a Wheelchair",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "m",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "m",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierDistanceWheelchair",
+                display: "Distance in a Wheelchair",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "m",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "m",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testEnvironmentalAudioExposure() throws {
@@ -2632,29 +2016,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.environmentalAudioExposure),
             quantity: HKQuantity(unit: .decibelAWeightedSoundPressureLevel(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierEnvironmentalAudioExposure",
-                    display: "Environmental Audio Exposure",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "dB(SPL)",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "dB(SPL)",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierEnvironmentalAudioExposure",
+                display: "Environmental Audio Exposure",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "dB(SPL)",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "dB(SPL)",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testHeadphoneAudioExposure() throws {
@@ -2662,29 +2038,21 @@ class HKQuantitySampleTests: XCTestCase {
             type: HKQuantityType(.headphoneAudioExposure),
             quantity: HKQuantity(unit: .decibelAWeightedSoundPressureLevel(), doubleValue: 100)
         )
-        
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                createCoding(
-                    code: "HKQuantityTypeIdentifierHeadphoneAudioExposure",
-                    display: "Headphone Audio Exposure",
-                    system: .apple
-                )
-            ]
-        )
-        
-        XCTAssertEqual(
-            observation.value,
-            .quantity(
-                Quantity(
-                    code: "dB(SPL)",
-                    system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
-                    unit: "dB(SPL)",
-                    value: 100.asFHIRDecimalPrimitive()
-                )
+        #expect(observation.code.coding == [
+            createCoding(
+                code: "HKQuantityTypeIdentifierHeadphoneAudioExposure",
+                display: "Headphone Audio Exposure",
+                system: .apple
             )
-        )
+        ])
+        #expect(observation.value == .quantity(
+            Quantity(
+                code: "dB(SPL)",
+                system: "http://unitsofmeasure.org".asFHIRURIPrimitive(),
+                unit: "dB(SPL)",
+                value: 100.asFHIRDecimalPrimitive()
+            )
+        ))
     }
     
     func testUnsupportedTypeSample() throws {
@@ -2694,9 +2062,9 @@ class HKQuantitySampleTests: XCTestCase {
             start: try startDate,
             end: try endDate
         )
-        XCTAssertThrowsError(
+        #expect(throws: HealthKitOnFHIRError.self) {
             try quantitySample.resource().get(if: Observation.self)
-        )
+        }
     }
     
     func testInvalidComponent() throws {
@@ -2713,14 +2081,12 @@ class HKQuantitySampleTests: XCTestCase {
             end: try endDate,
             objects: [nikeFuel]
         )
-        
-        XCTAssertThrowsError(
+        #expect(throws: HealthKitOnFHIRError.self) {
             try correlation.resource()
-        )
+        }
     }
     
-    func testUnsupportedType() throws {
-        XCTAssertThrowsError(
+    func testUnsupportedType() throws {#expect(throws: HealthKitOnFHIRError.self) {
             try HKVisionPrescription(
                 type: .glasses,
                 dateIssued: try startDate,
@@ -2728,7 +2094,7 @@ class HKQuantitySampleTests: XCTestCase {
                 device: nil,
                 metadata: nil
             ).resource()
-        )
+        }
     }
     
     func testUnsupportedMapping() throws {
@@ -2738,13 +2104,12 @@ class HKQuantitySampleTests: XCTestCase {
             start: try startDate,
             end: try endDate
         )
-        
-        XCTAssertEqual(sample.quantityType.codes, [])
+        #expect(sample.quantityType.codes.isEmpty)
     }
     
     func testCollectionSampleToResourceProxy() throws {
         func makeSample(numSteps: Int, date: DateComponents) throws -> HKQuantitySample {
-            let date = try XCTUnwrap(Calendar.current.date(from: date))
+            let date = try #require(Calendar.current.date(from: date))
             return HKQuantitySample(
                 type: HKQuantityType(.stepCount),
                 quantity: HKQuantity(unit: .count(), doubleValue: Double(numSteps)),
@@ -2761,15 +2126,15 @@ class HKQuantitySampleTests: XCTestCase {
             try makeSample(numSteps: 17, date: .init(year: 2025, month: 1, day: 1, hour: 5))
         ]
         let resources = try samples.mapIntoResourceProxies()
-        XCTAssertEqual(resources.count, samples.count)
+        #expect(resources.count == samples.count)
         for resource in resources {
-            XCTAssertNotNil(resource.get(if: Observation.self))
+            #expect(resource.get(if: Observation.self) != nil)
         }
     }
     
     func testCollectionSampleToResourceProxyWithUnsupportedSample() throws {
         func makeSample(numSteps: Int, date: DateComponents) throws -> HKQuantitySample {
-            let date = try XCTUnwrap(Calendar.current.date(from: date))
+            let date = try #require(Calendar.current.date(from: date))
             return HKQuantitySample(
                 type: HKQuantityType(.stepCount),
                 quantity: HKQuantity(unit: .count(), doubleValue: Double(numSteps)),
@@ -2786,13 +2151,13 @@ class HKQuantitySampleTests: XCTestCase {
             try makeSample(numSteps: 17, date: .init(year: 2025, month: 1, day: 1, hour: 5)),
             HKQuantitySample(type: HKQuantityType(.nikeFuel), quantity: HKQuantity(unit: .count(), doubleValue: 123), start: .now, end: .now)
         ]
-        XCTAssertThrowsError(
+        #expect(throws: HealthKitOnFHIRError.self) {
             try samples.mapIntoResourceProxies()
-        )
+        }
         let resources = try samples.compactMapIntoResourceProxies()
-        XCTAssertEqual(resources.count, samples.count - 1)
+        #expect(resources.count == samples.count - 1)
         for resource in resources {
-            XCTAssertNotNil(resource.get(if: Observation.self))
+            #expect(resource.get(if: Observation.self) != nil)
         }
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -57,28 +57,6 @@ class HKQuantitySampleTests: XCTestCase {
         )
     }
     
-    func testResourceComputedPropertyForward() throws {
-        let observation1 = try createObservationFrom(
-            type: HKQuantityType(.bloodGlucose),
-            quantity: HKQuantity(unit: HKUnit(from: "mg/dL"), doubleValue: 99)
-        )
-        let observation2: Observation = try {
-            let quantitySample = HKQuantitySample(
-                type: HKQuantityType(.bloodGlucose),
-                quantity: HKQuantity(unit: HKUnit(from: "mg/dL"), doubleValue: 99),
-                start: try startDate,
-                end: try endDate,
-                metadata: [:]
-            )
-            return try XCTUnwrap(quantitySample.resource.get(if: Observation.self))
-        }()
-        
-        observation2.issued = observation1.issued
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
-        XCTAssertEqual(try encoder.encode(observation1), try encoder.encode(observation1))
-    }
-    
     func testBloodGlucose() throws {
         let observation = try createObservationFrom(
             type: HKQuantityType(.bloodGlucose),

--- a/Tests/HealthKitOnFHIRTests/HKSampleTypeResourceTypeMapping.swift
+++ b/Tests/HealthKitOnFHIRTests/HKSampleTypeResourceTypeMapping.swift
@@ -9,26 +9,31 @@
 import HealthKit
 import HealthKitOnFHIR
 import ModelsR4
-import XCTest
+import Testing
 
 
-class HKSampleTypeResourceTypeMapping: XCTestCase {
-    func testHKSampleTypeMappingToObservation() {
-        try XCTAssertEqual(HKQuantityType(.activeEnergyBurned).resourceType, .observation)
-        try XCTAssertEqual(HKCorrelationType(.bloodPressure).resourceType, .observation)
-        try XCTAssertEqual(HKCategoryType(.abdominalCramps).resourceType, .observation)
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
+struct HKSampleTypeResourceTypeMapping {
+    @Test
+    func hkSampleTypeMappingToObservation() throws {
+        #expect(try HKQuantityType(.activeEnergyBurned).resourceType == .observation)
+        #expect(try HKCorrelationType(.bloodPressure).resourceType == .observation)
+        #expect(try HKCategoryType(.abdominalCramps).resourceType == .observation)
 
-        XCTAssertThrowsError(try HKSampleType.workoutType().resourceType)
+        #expect(throws: HealthKitOnFHIRError.self) {
+            try HKSampleType.workoutType().resourceType
+        }
     }
     
-    func testHKClinicalTypeMappingToResourceType() throws {
-        try XCTAssertEqual(HKClinicalType(.allergyRecord).resourceType, .allergyIntolerance)
-        try XCTAssertEqual(HKClinicalType(.conditionRecord).resourceType, .condition)
-        try XCTAssertEqual(HKClinicalType(.coverageRecord).resourceType, .coverage)
-        try XCTAssertEqual(HKClinicalType(.immunizationRecord).resourceType, .immunization)
-        try XCTAssertEqual(HKClinicalType(.labResultRecord).resourceType, .observation)
-        try XCTAssertEqual(HKClinicalType(.medicationRecord).resourceType, .medication)
-        try XCTAssertEqual(HKClinicalType(.procedureRecord).resourceType, .procedure)
-        try XCTAssertEqual(HKClinicalType(.vitalSignRecord).resourceType, .observation)
+    @Test
+    func hkClinicalTypeMappingToResourceType() throws {
+        #expect(try HKClinicalType(.allergyRecord).resourceType == .allergyIntolerance)
+        #expect(try HKClinicalType(.conditionRecord).resourceType == .condition)
+        #expect(try HKClinicalType(.coverageRecord).resourceType == .coverage)
+        #expect(try HKClinicalType(.immunizationRecord).resourceType == .immunization)
+        #expect(try HKClinicalType(.labResultRecord).resourceType == .observation)
+        #expect(try HKClinicalType(.medicationRecord).resourceType == .medication)
+        #expect(try HKClinicalType(.procedureRecord).resourceType == .procedure)
+        #expect(try HKClinicalType(.vitalSignRecord).resourceType == .observation)
     }
 }

--- a/Tests/HealthKitOnFHIRTests/HKWorkoutTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKWorkoutTests.swift
@@ -140,7 +140,7 @@ class HKWorkoutTests: XCTestCase {
 
             let observation = try XCTUnwrap(workoutSample.resource().get(if: Observation.self))
             let expectedValue = createCodeableConcept(
-                code: try activityType.workoutTypeDescription,
+                code: try activityType.fhirWorkoutTypeValue,
                 system: "http://developer.apple.com/documentation/healthkit"
             )
             XCTAssertEqual(observation.value, .codeableConcept(expectedValue))

--- a/Tests/HealthKitOnFHIRTests/HKWorkoutTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKWorkoutTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 
 @Suite
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
 struct HKWorkoutTests {
     static let supportedWorkoutActivityTypes: [HKWorkoutActivityType] = [
         .americanFootball,

--- a/Tests/HealthKitOnFHIRTests/ObservationExtensionsTests.swift
+++ b/Tests/HealthKitOnFHIRTests/ObservationExtensionsTests.swift
@@ -8,44 +8,36 @@
 
 @testable import HealthKitOnFHIR
 import ModelsR4
-import XCTest
+import Testing
 
 
-final class ObservationExtensionsTests: XCTestCase {
+@MainActor // to work around https://github.com/apple/FHIRModels/issues/36
+struct ObservationExtensionsTests {
+    @Test
     func testCollectionExtensionsIdentifier() throws {
         let observation = Observation(code: CodeableConcept(), status: FHIRPrimitive(.final))
         
         // First test all extensions with no value beeing present (collection is nil)
-        observation.appendIdentifier(
-            Identifier(id: "ID1")
-        )
+        observation.appendIdentifier(Identifier(id: "ID1"))
         
         // Assertions for the nil/non-present case:
-        XCTAssertEqual(
-            observation.identifier?.first,
-            Identifier(id: "ID1")
-        )
-        
+        #expect(observation.identifier?.first == Identifier(id: "ID1"))
         
         // Now Append multiple elements and in a non-nil collection:
-        observation.appendIdentifiers(
-            [
-                Identifier(id: "ID2"),
-                Identifier(id: "ID3")
-            ]
-        )
+        observation.appendIdentifiers([
+            Identifier(id: "ID2"),
+            Identifier(id: "ID3")
+        ])
         
         // Assertions for the non-nil collection case:
-        XCTAssertEqual(
-            observation.identifier,
-            [
-                Identifier(id: "ID1"),
-                Identifier(id: "ID2"),
-                Identifier(id: "ID3")
-            ]
-        )
+        #expect(observation.identifier == [
+            Identifier(id: "ID1"),
+            Identifier(id: "ID2"),
+            Identifier(id: "ID3")
+        ])
     }
     
+    @Test
     func testCollectionExtensionsCoding() throws {
         let observation = Observation(code: CodeableConcept(), status: FHIRPrimitive(.final))
         
@@ -59,88 +51,71 @@ final class ObservationExtensionsTests: XCTestCase {
         )
         
         // Assertions for the nil/non-present case:
-        XCTAssertEqual(
-            observation.code.coding?.first,
+        #expect(observation.code.coding?.first == Coding(
+            code: "Code1",
+            display: "Display1",
+            system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test1.system"))
+        ))
+        
+        // Now Append multiple elements and in a non-nil collection:
+        observation.appendCodings([
+            Coding(
+                code: "Code2",
+                display: "Display2",
+                system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test2.system"))
+            ),
+            Coding(
+                code: "Code3",
+                display: "Display3",
+                system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test3.system"))
+            )
+        ])
+        
+        // Assertions for the non-nil collection case:
+        #expect(observation.code.coding == [
             Coding(
                 code: "Code1",
                 display: "Display1",
                 system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test1.system"))
+            ),
+            Coding(
+                code: "Code2",
+                display: "Display2",
+                system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test2.system"))
+            ),
+            Coding(
+                code: "Code3",
+                display: "Display3",
+                system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test3.system"))
             )
-        )
-        
-        
-        // Now Append multiple elements and in a non-nil collection:
-        observation.appendCodings(
-            [
-                Coding(
-                    code: "Code2",
-                    display: "Display2",
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test2.system"))
-                ),
-                Coding(
-                    code: "Code3",
-                    display: "Display3",
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test3.system"))
-                )
-            ]
-        )
-        
-        // Assertions for the non-nil collection case:
-        XCTAssertEqual(
-            observation.code.coding,
-            [
-                Coding(
-                    code: "Code1",
-                    display: "Display1",
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test1.system"))
-                ),
-                Coding(
-                    code: "Code2",
-                    display: "Display2",
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test2.system"))
-                ),
-                Coding(
-                    code: "Code3",
-                    display: "Display3",
-                    system: FHIRPrimitive(FHIRURI(stringLiteral: "https://test3.system"))
-                )
-            ]
-        )
+        ])
     }
     
+    @Test
     func testCollectionExtensionsCategories() throws {
         let observation = Observation(code: CodeableConcept(), status: FHIRPrimitive(.final))
         
         // First test all extensions with no value beeing present (collection is nil)
-        observation.appendCategory(
-            CodeableConcept(id: "Concept1")
-        )
+        observation.appendCategory(CodeableConcept(id: "Concept1"))
         
         // Assertions for the nil/non-present case:
-        XCTAssertEqual(
-            observation.category?.first,
-            CodeableConcept(id: "Concept1")
-        )
+        #expect(observation.category?.first == CodeableConcept(id: "Concept1"))
         
         // Now Append multiple elements and in a non-nil collection:
-        observation.appendCategories(
-            [
-                CodeableConcept(id: "Concept2"),
-                CodeableConcept(id: "Concept3")
-            ]
-        )
+        observation.appendCategories([
+            CodeableConcept(id: "Concept2"),
+            CodeableConcept(id: "Concept3")
+        ])
 
         // Assertions for the non-nil collection case:
-        XCTAssertEqual(
-            observation.category,
-            [
-                CodeableConcept(id: "Concept1"),
-                CodeableConcept(id: "Concept2"),
-                CodeableConcept(id: "Concept3")
-            ]
-        )
+        #expect(observation.category == [
+            CodeableConcept(id: "Concept1"),
+            CodeableConcept(id: "Concept2"),
+            CodeableConcept(id: "Concept3")
+        ])
     }
     
+    @Test
     func testCollectionExtensionsComponents() throws {
         let observation = Observation(code: CodeableConcept(), status: FHIRPrimitive(.final))
         
@@ -153,13 +128,10 @@ final class ObservationExtensionsTests: XCTestCase {
         )
         
         // Assertions for the nil/non-present case:
-        XCTAssertEqual(
-            observation.component?.first,
-            ObservationComponent(
-                code: CodeableConcept(id: "Concept4"),
-                value: .boolean(true.asPrimitive())
-            )
-        )
+        #expect(observation.component?.first == ObservationComponent(
+            code: CodeableConcept(id: "Concept4"),
+            value: .boolean(true.asPrimitive())
+        ))
         
         
         // Now Append multiple elements and in a non-nil collection:
@@ -175,22 +147,19 @@ final class ObservationExtensionsTests: XCTestCase {
         ])
         
         // Assertions for the non-nil collection case:
-        XCTAssertEqual(
-            observation.component,
-            [
-                ObservationComponent(
-                    code: CodeableConcept(id: "Concept4"),
-                    value: .boolean(true.asPrimitive())
-                ),
-                ObservationComponent(
-                    code: CodeableConcept(id: "Concept5"),
-                    value: .string("Test".asFHIRStringPrimitive())
-                ),
-                ObservationComponent(
-                    code: CodeableConcept(id: "Concept6"),
-                    value: .integer(10.asFHIRIntegerPrimitive())
-                )
-            ]
-        )
+        #expect(observation.component == [
+            ObservationComponent(
+                code: CodeableConcept(id: "Concept4"),
+                value: .boolean(true.asPrimitive())
+            ),
+            ObservationComponent(
+                code: CodeableConcept(id: "Concept5"),
+                value: .string("Test".asFHIRStringPrimitive())
+            ),
+            ObservationComponent(
+                code: CodeableConcept(id: "Concept6"),
+                value: .integer(10.asFHIRIntegerPrimitive())
+            )
+        ])
     }
 }

--- a/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
+++ b/Tests/HealthKitOnFHIRTests/TimeZoneTests.swift
@@ -28,7 +28,6 @@ struct TimeZoneTests { // swiftlint:disable:this type_body_length
     func createDatesFor(timeZone: String) throws -> (start: Date, end: Date) {
         let startComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 9, minute: 00, second: 0)
         let endComponents = DateComponents(year: 2024, month: 12, day: 1, hour: 10, minute: 45, second: 0)
-        
         return (
             try getTimeZoneDate(startComponents, timeZoneName: timeZone),
             try getTimeZoneDate(endComponents, timeZoneName: timeZone)

--- a/Tests/UITests/TestApp/Views/CheckMappingCompletenessView.swift
+++ b/Tests/UITests/TestApp/Views/CheckMappingCompletenessView.swift
@@ -1,0 +1,73 @@
+//
+// This source file is part of the HealthKitOnFHIR open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKitOnFHIR
+import SpeziHealthKit
+import SwiftUI
+
+
+struct CheckMappingCompletenessView: View {
+    private struct TestResult {
+        var missingQuantityTypes: Set<String> = []
+        var missingCategoryTypes: Set<String> = []
+        var missingCorrelationTypes: Set<String> = []
+        
+        var isEmpty: Bool {
+            missingQuantityTypes.isEmpty && missingCategoryTypes.isEmpty && missingCorrelationTypes.isEmpty
+        }
+    }
+    
+    
+    var body: some View {
+        Form {
+            let testResult = runCheck()
+            Section {
+                Text(testResult.isEmpty ? "All Fine!" : "Missing Mapping Entries!")
+            }
+            makeSection(title: "Missing Quantity Types", for: testResult.missingQuantityTypes)
+            makeSection(title: "Missing Category Types", for: testResult.missingCategoryTypes)
+            makeSection(title: "Missing Correlation Types", for: testResult.missingCorrelationTypes)
+        }
+    }
+    
+    @ViewBuilder
+    private func makeSection(title: String, for types: some Collection<String>) -> some View {
+        if !types.isEmpty {
+            Section(title) {
+                ForEach(types.sorted(), id: \.self) { type in
+                    Text(type)
+                }
+            }
+        }
+    }
+    
+    private func runCheck() -> TestResult {
+        var result = TestResult()
+        let mappings = HKSampleMapping.default
+        for type in HKQuantityType.allKnownQuantities {
+            guard mappings.quantitySampleMapping[type] == nil else {
+                continue
+            }
+            result.missingQuantityTypes.insert(type.identifier)
+        }
+        for type in HKCategoryType.allKnownCategories {
+            guard mappings.categorySampleMapping[type] == nil else {
+                continue
+            }
+            result.missingCategoryTypes.insert(type.identifier)
+        }
+        for type in HKCorrelationType.allKnownCorrelations {
+            guard mappings.correlationMapping[type] == nil else {
+                continue
+            }
+            result.missingCorrelationTypes.insert(type.identifier)
+        }
+        return result
+    }
+}

--- a/Tests/UITests/TestApp/Views/CheckMappingCompletenessView.swift
+++ b/Tests/UITests/TestApp/Views/CheckMappingCompletenessView.swift
@@ -18,9 +18,9 @@ struct CheckMappingCompletenessView: View {
             let typeIdentifier: String
             let unitString: String?
         }
-        var missingQuantityTypes: Set<Entry> = []
-        var missingCategoryTypes: Set<Entry> = []
-        var missingCorrelationTypes: Set<Entry> = []
+        var missingQuantityTypes = Set<Entry>()
+        var missingCategoryTypes = Set<Entry>()
+        var missingCorrelationTypes = Set<Entry>()
         
         var isEmpty: Bool {
             missingQuantityTypes.isEmpty && missingCategoryTypes.isEmpty && missingCorrelationTypes.isEmpty

--- a/Tests/UITests/TestApp/Views/CheckMappingCompletenessView.swift
+++ b/Tests/UITests/TestApp/Views/CheckMappingCompletenessView.swift
@@ -30,7 +30,6 @@ struct CheckMappingCompletenessView: View {
     
     var body: some View {
         Form {
-            let _ = print(SampleType.environmentalSoundReduction.displayUnit.unitString)
             let testResult = runCheck()
             Section {
                 Text(testResult.isEmpty ? "All Fine!" : "Missing Mapping Entries!")

--- a/Tests/UITests/TestApp/Views/ContentView.swift
+++ b/Tests/UITests/TestApp/Views/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
                     NavigationLink("Health Records", destination: HealthRecordsTestView())
                     NavigationLink("Create Workout", destination: CreateWorkoutView())
                     NavigationLink("Export Data", destination: ExportDataView())
+                    NavigationLink("Mapping Completeness", destination: CheckMappingCompletenessView())
                 }
             }
             .navigationBarTitle("HealthKitOnFHIR Tests")

--- a/Tests/UITests/TestApp/Views/CreateWorkoutView.swift
+++ b/Tests/UITests/TestApp/Views/CreateWorkoutView.swift
@@ -41,35 +41,20 @@ struct CreateWorkoutView: View {
         guard let healthStore = self.manager.healthStore else {
             throw HKError(.errorHealthDataUnavailable)
         }
-
         let configuration = HKWorkoutConfiguration()
         configuration.activityType = activityType
         configuration.locationType = .indoor
-
-        let workoutBuilder = HKWorkoutBuilder(healthStore: healthStore, configuration: configuration, device: nil)
-
-        return try await withCheckedThrowingContinuation { continuation in
-            workoutBuilder.beginCollection(withStart: startDate) { success, error in
-                guard success else {
-                    continuation.resume(throwing: error ?? HKError(.errorHealthDataUnavailable))
-                    return
-                }
-
-                workoutBuilder.endCollection(withEnd: endDate) { success, error in
-                    guard success else {
-                        continuation.resume(throwing: error ?? HKError(.errorHealthDataUnavailable))
-                        return
-                    }
-
-                    workoutBuilder.finishWorkout { workout, error in
-                        if let workout = workout {
-                            continuation.resume(returning: workout)
-                        } else {
-                            continuation.resume(throwing: error ?? HKError(.errorHealthDataUnavailable))
-                        }
-                    }
-                }
-            }
+        let workoutBuilder = HKWorkoutBuilder(
+            healthStore: healthStore,
+            configuration: configuration,
+            device: nil
+        )
+        try await workoutBuilder.beginCollection(at: startDate)
+        try await workoutBuilder.endCollection(at: endDate)
+        if let workout = try await workoutBuilder.finishWorkout() {
+            return workout
+        } else {
+            throw HKError(.errorHealthDataUnavailable)
         }
     }
 

--- a/Tests/UITests/TestApp/Views/CreateWorkoutView.swift
+++ b/Tests/UITests/TestApp/Views/CreateWorkoutView.swift
@@ -84,7 +84,7 @@ struct CreateWorkoutView: View {
                 activityType: .running
             )
 
-            let observation = try workout.resource.get()
+            let observation = try workout.resource().get()
 
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -93,4 +93,13 @@ class TestAppUITests: XCTestCase {
         // Dismiss results view
         app.swipeDown(velocity: XCUIGestureVelocity.fast)
     }
+    
+    @MainActor
+    func testMappingCompleteness() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        app.buttons["Mapping Completeness"].tap()
+        XCTAssertTrue(app.staticTexts["All Fine!"].waitForExistence(timeout: 2))
+    }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -55,7 +55,7 @@ class TestAppUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
-        try exitAppAndOpenHealth(.electrocardiograms)
+        try launchAndAddSample(healthApp: .healthApp, .electrocardiogram())
 
         app.launch()
         XCTAssert(app.wait(for: .runningForeground, timeout: 6.0))

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -501,7 +501,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTHealthKit.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.3.3;
+				minimumVersion = 1.1.2;
 			};
 		};
 		2F1B52D52A4F7909003AE151 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {
@@ -509,7 +509,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.5;
+				minimumVersion = 1.2.1;
 			};
 		};
 		80DE0CEF2DBAC0E800B519CF /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
@@ -517,7 +517,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.2;
+				minimumVersion = 1.1.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2F1B52D42A4F78A5003AE151 /* XCTHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F1B52D32A4F78A5003AE151 /* XCTHealthKit */; };
 		2F1B52D72A4F7909003AE151 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F1B52D62A4F7909003AE151 /* XCTestExtensions */; };
 		2F68C3C8292EA52000B3E12C /* HealthKitOnFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2F68C3C7292EA52000B3E12C /* HealthKitOnFHIR */; };
+		80DE0CF12DBAC0E800B519CF /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 80DE0CF02DBAC0E800B519CF /* SpeziHealthKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F68C3C8292EA52000B3E12C /* HealthKitOnFHIR in Frameworks */,
+				80DE0CF12DBAC0E800B519CF /* SpeziHealthKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,6 +116,7 @@
 			name = TestApp;
 			packageProductDependencies = (
 				2F68C3C7292EA52000B3E12C /* HealthKitOnFHIR */,
+				80DE0CF02DBAC0E800B519CF /* SpeziHealthKit */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -175,6 +178,7 @@
 			packageReferences = (
 				2F1B52D22A4F78A5003AE151 /* XCRemoteSwiftPackageReference "XCTHealthKit" */,
 				2F1B52D52A4F7909003AE151 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
+				80DE0CEF2DBAC0E800B519CF /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
 			);
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
@@ -508,6 +512,14 @@
 				minimumVersion = 0.4.5;
 			};
 		};
+		80DE0CEF2DBAC0E800B519CF /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -524,6 +536,11 @@
 		2F68C3C7292EA52000B3E12C /* HealthKitOnFHIR */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = HealthKitOnFHIR;
+		};
+		80DE0CF02DBAC0E800B519CF /* SpeziHealthKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 80DE0CEF2DBAC0E800B519CF /* XCRemoteSwiftPackageReference "SpeziHealthKit" */;
+			productName = SpeziHealthKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
# more sample types

## :recycle: Current situation & Problem
HealthKitOnFHIR currently doesn't support all sample types supported by HealthKit.
This PR adds support for additional category and quantity types, attempting to bring the set of sample types supported by HealthKitOnFHIR in line with what's supported by SpeziHealthKit (which, to the best of my knowledge, should currently support all sample types defined by HealthKit).

The PR also reworks the category sample handling a bit, to reduce code duplication and make it easier to add additional types in the future.
It also improves the FHIR observation creation for `HKCategorySample`s, by also handling the metadata associated with some category types.

Additionally, we remove the `resource` computed property, in preparation for an upcoming 1.0 release.


## :gear: Release Notes
- added support for more sample types.


## :books: Documentation
n/a; the behaviour and external API should remain unchanged.

most of the new internal components are documented.


## :white_check_mark: Testing
The existing tests all pass unchanged.
There is a new UI test that verifies that our mapping contains entries for all sample types known to SpeziHealthKit (the reaosn this is a UI test is to avoid establishing a dependency between the HealthKitOnFHIR package and Spezi; this way only the UITests TestApp depends on Spezi, which IMO is ok)
We might need to add some additional test cases, to cover the new sample types.


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
