### PR TITLE
make some observation extensions public

### DIFF
--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
@@ -38,35 +38,43 @@ extension Observation {
     }
     
     
-    func appendIdentifier(_ identifier: Identifier) {
+    /// Appends an `Identifier` to the `Observation`
+    public func appendIdentifier(_ identifier: Identifier) {
         appendElement(identifier, to: \.identifier)
     }
     
-    func appendIdentifiers(_ identifiers: [Identifier]) {
+    /// Appends multiple `Identifier`s to the `Observation`
+    public func appendIdentifiers(_ identifiers: [Identifier]) {
         appendElements(identifiers, to: \.identifier)
     }
     
-    func appendCategory(_ category: CodeableConcept) {
+    /// Appends a `CodeableConcept` to the `Observation`
+    public func appendCategory(_ category: CodeableConcept) {
         appendElement(category, to: \.category)
     }
     
-    func appendCategories(_ categories: [CodeableConcept]) {
+    /// Appends multiple `CodeableConcept`s to the `Observation`
+    public func appendCategories(_ categories: [CodeableConcept]) {
         appendElements(categories, to: \.category)
     }
     
-    func appendCoding(_ coding: Coding) {
+    /// Appends a `Coding` to the `Observation`
+    public func appendCoding(_ coding: Coding) {
         appendElement(coding, to: \.code.coding)
     }
     
-    func appendCodings(_ codings: [Coding]) {
+    /// Appends multiple `Coding`s to the `Observation`
+    public func appendCodings(_ codings: [Coding]) {
         appendElements(codings, to: \.code.coding)
     }
     
-    func appendComponent(_ component: ObservationComponent) {
+    /// Appends an `ObservationComponent` to the `Observation`
+    public func appendComponent(_ component: ObservationComponent) {
         appendElement(component, to: \.component)
     }
     
-    func appendComponents(_ components: [ObservationComponent]) {
+    /// Appends multiple `ObservationComponent`s to the `Observation`
+    public func appendComponents(_ components: [ObservationComponent]) {
         appendElements(components, to: \.component)
     }
 }

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
@@ -12,29 +12,21 @@ import ModelsR4
 
 
 extension Observation {
-    private func appendElement<T>(_ element: T, to collection: ReferenceWritableKeyPath<Observation, [T]?>) {
-        // swiftlint:disable:previous discouraged_optional_collection
-        // Unfortunately we need to use an optional collection here as the ModelsR4 modules uses optional collections in the Observation type.
-        guard self[keyPath: collection] != nil else {
-            self[keyPath: collection] = [element]
-            return
-        }
-        self[keyPath: collection]?.append(element)
+    private func appendElement<C: RangeReplaceableCollection>(_ element: C.Element, to keyPath: ReferenceWritableKeyPath<Observation, C?>) {
+        appendElements(CollectionOfOne(element), to: keyPath)
     }
     
-    
-    private func appendElements<T>(_ elements: some Collection<T>, to collection: ReferenceWritableKeyPath<Observation, [T]?>) {
-        // swiftlint:disable:previous discouraged_optional_collection
-        // Unfortunately we need to use an optional collection here as the ModelsR4 modules uses optional collections in the Observation type.
-        if self[keyPath: collection] == nil {
-            self[keyPath: collection] = []
-            self[keyPath: collection]?.reserveCapacity(elements.count)
+    private func appendElements<C: RangeReplaceableCollection>(
+        _ elements: some Collection<C.Element>,
+        to keyPath: ReferenceWritableKeyPath<Observation, C?>
+    ) {
+        if self[keyPath: keyPath] == nil {
+            self[keyPath: keyPath] = C()
+            self[keyPath: keyPath]?.reserveCapacity(elements.count)
         } else {
-            self[keyPath: collection]?.reserveCapacity((self[keyPath: collection]?.count ?? 0) + elements.count)
+            self[keyPath: keyPath]?.reserveCapacity((self[keyPath: keyPath]?.count ?? 0) + elements.count)
         }
-        for element in elements {
-            appendElement(element, to: collection)
-        }
+        self[keyPath: keyPath]?.append(contentsOf: elements)
     }
     
     

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Collections.swift
@@ -23,7 +23,7 @@ extension Observation {
     }
     
     
-    private func appendElements<T>(_ elements: [T], to collection: ReferenceWritableKeyPath<Observation, [T]?>) {
+    private func appendElements<T>(_ elements: some Collection<T>, to collection: ReferenceWritableKeyPath<Observation, [T]?>) {
         // swiftlint:disable:previous discouraged_optional_collection
         // Unfortunately we need to use an optional collection here as the ModelsR4 modules uses optional collections in the Observation type.
         if self[keyPath: collection] == nil {
@@ -44,7 +44,7 @@ extension Observation {
     }
     
     /// Appends multiple `Identifier`s to the `Observation`
-    public func appendIdentifiers(_ identifiers: [Identifier]) {
+    public func appendIdentifiers(_ identifiers: some Collection<Identifier>) {
         appendElements(identifiers, to: \.identifier)
     }
     
@@ -54,7 +54,7 @@ extension Observation {
     }
     
     /// Appends multiple `CodeableConcept`s to the `Observation`
-    public func appendCategories(_ categories: [CodeableConcept]) {
+    public func appendCategories(_ categories: some Collection<CodeableConcept>) {
         appendElements(categories, to: \.category)
     }
     
@@ -64,7 +64,7 @@ extension Observation {
     }
     
     /// Appends multiple `Coding`s to the `Observation`
-    public func appendCodings(_ codings: [Coding]) {
+    public func appendCodings(_ codings: some Collection<Coding>) {
         appendElements(codings, to: \.code.coding)
     }
     
@@ -74,7 +74,7 @@ extension Observation {
     }
     
     /// Appends multiple `ObservationComponent`s to the `Observation`
-    public func appendComponents(_ components: [ObservationComponent]) {
+    public func appendComponents(_ components: some Collection<ObservationComponent>) {
         appendElements(components, to: \.component)
     }
 }

--- a/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
+++ b/Sources/HealthKitOnFHIR/Observation Extensions/Observation+Dates.swift
@@ -12,7 +12,8 @@ import ModelsR4
 
 
 extension Observation {
-    func setEffective(startDate: Date, endDate: Date, timeZone: TimeZone) throws {
+    /// Sets the `Observation`'s effective date.
+    public func setEffective(startDate: Date, endDate: Date, timeZone: TimeZone) throws {
         if startDate == endDate {
             effective = .dateTime(FHIRPrimitive(try DateTime(date: startDate, timeZone: timeZone)))
         } else {
@@ -23,7 +24,8 @@ extension Observation {
         }
     }
     
-    func setIssued(on date: Date) throws {
+    /// Sets the `Observation`'s issued date.
+    public func setIssued(on date: Date) throws {
         issued = FHIRPrimitive(try Instant(date: date))
     }
 }


### PR DESCRIPTION
# make some observation extensions public

## :recycle: Current situation & Problem
This PR makes some of the `Observation` extensions defined by HealthKitOnFHIR public, so that they can also be used by other apps/packages to construct `Observation`s


## :gear: Release Notes
- made some `Observation` extensions public


## :books: Documentation
the now-public functions are documented


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
