### PR TITLE
fix crash when encountering infinity values#2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ import PackageDescription
 
 /// Whether the package should run SwiftLint as part of its build process.
 ///
-/// Set this to `false` before commiting any changes.
+/// Set this to `false` before committing any changes.
 let enableSwiftLintPlugin = false
 
 
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
-        .package(url: "https://github.com/StanfordBDHG/FHIRModelsExtensions.git", branch: "lukas/safe-decimal-init"),
+        .package(url: "https://github.com/StanfordBDHG/FHIRModelsExtensions.git", from: "0.1.1"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.0")

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:6.2
-
 //
 // This source file is part of the HealthKitOnFHIR open source project
 // 
@@ -11,6 +10,11 @@
 import CompilerPluginSupport
 import class Foundation.ProcessInfo
 import PackageDescription
+
+/// Whether the package should run SwiftLint as part of its build process.
+///
+/// Set this to `false` before commiting any changes.
+let enableSwiftLintPlugin = false
 
 
 let package = Package(
@@ -26,11 +30,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
-        .package(url: "https://github.com/StanfordBDHG/FHIRModelsExtensions.git", from: "0.1.0"),
+        .package(url: "https://github.com/StanfordBDHG/FHIRModelsExtensions.git", branch: "lukas/safe-decimal-init"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.0")
-    ] + swiftLintPackage(),
+    ] + swiftLintPackage,
     targets: [
         .macro(
             name: "HealthKitOnFHIRMacrosImpl",
@@ -40,13 +44,15 @@ let package = Package(
                 .product(name: "SwiftDiagnostics", package: "swift-syntax"),
                 .product(name: "Algorithms", package: "swift-algorithms")
             ],
-            swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
+            plugins: [] + swiftLintPlugin
         ),
         .target(
             name: "HealthKitOnFHIRMacros",
             dependencies: [
                 .target(name: "HealthKitOnFHIRMacrosImpl")
-            ]
+            ],
+            plugins: [] + swiftLintPlugin
         ),
         .target(
             name: "HealthKitOnFHIR",
@@ -59,7 +65,7 @@ let package = Package(
                 .process("Resources")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
-            plugins: [] + swiftLintPlugin()
+            plugins: [] + swiftLintPlugin
         ),
         .testTarget(
             name: "HealthKitOnFHIRTests",
@@ -68,7 +74,7 @@ let package = Package(
                 .product(name: "SpeziFoundation", package: "SpeziFoundation")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
-            plugins: [] + swiftLintPlugin()
+            plugins: [] + swiftLintPlugin
         ),
         .testTarget(
             name: "HealthKitOnFHIRMacrosTests",
@@ -78,24 +84,26 @@ let package = Package(
                 .product(name: "FHIRModelsExtensions", package: "FHIRModelsExtensions"),
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
-            ]
+            ],
+            plugins: [] + swiftLintPlugin
         )
     ]
 )
 
 
-func swiftLintPlugin() -> [Target.PluginUsage] {
-    // Fully quit Xcode and open again with `open --env SPEZI_DEVELOPMENT_SWIFTLINT /Applications/Xcode.app`
-    if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]
+// MARK: SwiftLint support
+
+var swiftLintPlugin: [Target.PluginUsage] {
+    if enableSwiftLintPlugin {
+        [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")]
     } else {
         []
     }
 }
 
-func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
-    if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
+var swiftLintPackage: [PackageDescription.Package.Dependency] {
+    if enableSwiftLintPlugin {
+        [.package(url: "https://github.com/SimplyDanny/SwiftLintPlugins.git", from: "0.63.2")]
     } else {
         []
     }

--- a/Sources/HealthKitOnFHIR/FHIR Extensions/FHIR Extension Builder/FHIRExtensionBuilder+Metadata.swift
+++ b/Sources/HealthKitOnFHIR/FHIR Extensions/FHIR Extension Builder/FHIRExtensionBuilder+Metadata.swift
@@ -51,53 +51,53 @@ extension FHIRExtensionBuilderProtocol where Self == FHIRExtensionBuilder<HKObje
                 case let value as HKQuantity:
                     switch key {
                     case HKMetadataKeyWeatherTemperature:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .weatherTemperature))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .weatherTemperature))
                     case HKMetadataKeyWeatherHumidity:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .weatherHumidity))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .weatherHumidity))
                     case HKMetadataKeySessionEstimate:
                         guard let sample = object as? HKQuantitySample,
                               let mapping = HKQuantitySampleMapping.default[sample.quantityType] else {
                             continue // should be unreachable. skipping
                         }
-                        extensionValue = .quantity(value.buildQuantity(mapping: mapping))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: mapping))
                     case HKMetadataKeyHeartRateRecoveryActivityDuration:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .heartRateRecoveryActivityDuration))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .heartRateRecoveryActivityDuration))
                     case HKMetadataKeyHeartRateRecoveryMaxObservedRecoveryHeartRate:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .heartRateRecoveryMaxObservedRecoveryHeartRate))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .heartRateRecoveryMaxObservedRecoveryHeartRate))
                     case HKMetadataKeyAverageSpeed:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .averageSpeed))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .averageSpeed))
                     case HKMetadataKeyMaximumSpeed:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .maximumSpeed))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .maximumSpeed))
                     case HKMetadataKeyAlpineSlopeGrade:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .alpineSlopeGrade))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .alpineSlopeGrade))
                     case HKMetadataKeyElevationAscended:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .elevationAscended))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .elevationAscended))
                     case HKMetadataKeyElevationDescended:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .elevationDescended))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .elevationDescended))
                     case HKMetadataKeyFitnessMachineDuration:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .fitnessMachineDuration))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .fitnessMachineDuration))
                     case HKMetadataKeyIndoorBikeDistance:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .indoorBikeDistance))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .indoorBikeDistance))
                     case HKMetadataKeyCrossTrainerDistance:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .crossTrainerDistance))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .crossTrainerDistance))
                     case HKMetadataKeyHeartRateEventThreshold:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .highHeartRateEventThreshold))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .highHeartRateEventThreshold))
                     case HKMetadataKeyAverageMETs:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .averageMETs))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .averageMETs))
                     case HKMetadataKeyAudioExposureLevel:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .audioExposureLevel))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .audioExposureLevel))
                     case HKMetadataKeyAudioExposureDuration:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .audioExposureDuration))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .audioExposureDuration))
                     case HKMetadataKeyBarometricPressure:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .barometricPressure))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .barometricPressure))
                     case HKMetadataKeyVO2MaxValue:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .vo2MaxValue))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .vo2MaxValue))
                     case HKMetadataKeyLowCardioFitnessEventThreshold:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .lowCardioFitnessEventThreshold))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .lowCardioFitnessEventThreshold))
                     case HKMetadataKeyHeadphoneGain:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .headphoneGain))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .headphoneGain))
                     case HKMetadataKeyMaximumLightIntensity:
-                        extensionValue = .quantity(value.buildQuantity(mapping: .maximumLightIntensity))
+                        extensionValue = .quantity(try value.buildQuantity(mapping: .maximumLightIntensity))
                     default:
                         print("Encountered unexpected HKQuantity metadata value for key '\(key)': \(value). Skipping.")
                         continue

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKElectrocardiogram+Observation.swift
@@ -98,7 +98,7 @@ extension HKElectrocardiogram: FHIRObservationBuildable {
                 code: mapping.numberOfVoltageMeasurements.unit.code?.asFHIRStringPrimitive(),
                 system: mapping.numberOfVoltageMeasurements.unit.system?.asFHIRURIPrimitive(),
                 unit: mapping.numberOfVoltageMeasurements.unit.unit.asFHIRStringPrimitive(),
-                value: Double(numberOfVoltageMeasurements).asFHIRDecimalPrimitive()
+                value: try Double(numberOfVoltageMeasurements).asFHIRDecimalPrimitiveSafe()
             )
         )
         observation.appendComponent(numberOfVoltageMeasurementsComponent)
@@ -117,7 +117,7 @@ extension HKElectrocardiogram: FHIRObservationBuildable {
                     code: mapping.samplingFrequency.unit.code?.asFHIRStringPrimitive(),
                     system: mapping.samplingFrequency.unit.system?.asFHIRURIPrimitive(),
                     unit: mapping.samplingFrequency.unit.unit.asFHIRStringPrimitive(),
-                    value: samplingFrequency.doubleValue(for: mapping.samplingFrequency.unit.hkunit).asFHIRDecimalPrimitive()
+                    value: try samplingFrequency.doubleValue(for: mapping.samplingFrequency.unit.hkunit).asFHIRDecimalPrimitiveSafe()
                 )
             )
             observation.appendComponent(samplingFrequencyComponent)
@@ -146,7 +146,7 @@ extension HKElectrocardiogram: FHIRObservationBuildable {
                     code: mapping.averageHeartRate.unit.code?.asFHIRStringPrimitive(),
                     system: mapping.averageHeartRate.unit.system?.asFHIRURIPrimitive(),
                     unit: mapping.averageHeartRate.unit.unit.asFHIRStringPrimitive(),
-                    value: averageHeartRate.doubleValue(for: mapping.averageHeartRate.unit.hkunit).asFHIRDecimalPrimitive()
+                    value: try averageHeartRate.doubleValue(for: mapping.averageHeartRate.unit.hkunit).asFHIRDecimalPrimitiveSafe()
                 )
             )
             observation.appendComponent(averageHeartRateComponent)
@@ -233,7 +233,7 @@ extension HKElectrocardiogram: FHIRObservationBuildable {
                         unit: mapping.unit.unit.asFHIRStringPrimitive(),
                         value: 0.asFHIRDecimalPrimitive()
                     ),
-                    period: period.asFHIRDecimalPrimitive()
+                    period: try period.asFHIRDecimalPrimitiveSafe()
                 )
             )
             observation.appendComponent(voltageMeasurementBatchComponent)

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKQuantitySample+Observation.swift
@@ -19,7 +19,7 @@ extension HKQuantitySample: FHIRObservationBuildable {
         for code in mapping.codings {
             observation.appendCoding(code.coding)
         }
-        observation.value = .quantity(quantity.buildQuantity(mapping: mapping))
+        observation.value = .quantity(try quantity.buildQuantity(mapping: mapping))
     }
 }
 
@@ -32,22 +32,22 @@ extension HKQuantity {
         guard let mapping = mappings[quantityType] else {
             throw HealthKitOnFHIRError.notSupported
         }
-        return buildObservationComponent(mapping: mapping)
+        return try buildObservationComponent(mapping: mapping)
     }
     
-    func buildObservationComponent(mapping: HKQuantitySampleMapping) -> ObservationComponent {
+    func buildObservationComponent(mapping: HKQuantitySampleMapping) throws -> ObservationComponent {
         ObservationComponent(
             code: CodeableConcept(coding: mapping.codings.map(\.coding)),
-            value: .quantity(buildQuantity(mapping: mapping))
+            value: .quantity(try buildQuantity(mapping: mapping))
         )
     }
     
-    func buildQuantity(mapping: HKQuantitySampleMapping) -> Quantity {
+    func buildQuantity(mapping: HKQuantitySampleMapping) throws -> Quantity {
         Quantity(
             code: mapping.unit.code?.asFHIRStringPrimitive(),
             system: mapping.unit.system?.asFHIRURIPrimitive(),
             unit: mapping.unit.unit.asFHIRStringPrimitive(),
-            value: self.doubleValue(for: mapping.unit.hkunit).asFHIRDecimalPrimitive()
+            value: try self.doubleValue(for: mapping.unit.hkunit).asFHIRDecimalPrimitiveSafe()
         )
     }
 }

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -86,7 +86,7 @@ extension Sequence where Element: HKSample {
     
     /// Produces an Array of FHIR `ResourceProxies`.
     ///
-    /// This function is equivalent to calling ``HealthKit/HKSample/resource(withMapping:issuedDate:extensions:)`` on every element in the sequence, andd filtering out those elememt for which the call raised an error.
+    /// This function is equivalent to calling ``HealthKit/HKSample/resource(withMapping:issuedDate:extensions:)`` on every element in the sequence, and filtering out those elememt for which the call raised an error.
     ///
     /// - Note: This method provides significant performance improvements as compared to calling ``HealthKit/HKSample/resource(withMapping:issuedDate:extensions:)`` for each element in the collection.
     ///

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -19,7 +19,8 @@ extension HKSample {
     /// - parameter extensions: Any ``FHIRExtensionBuilder``s that should be applied to each of the produced observations.
     ///     The ``FHIRExtensionBuilder/sourceDevice-9m1t7``, ``FHIRExtensionBuilder/sourceRevision-8b3xb``, and ``FHIRExtensionBuilder/metadata`` extension builders are always enabled when creating a FHIR `Observation`s from a `HKSample`.
     /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    /// - throws: If a specific `HKSample` type is currently not supported the property returns an ``HealthKitOnFHIRError/notSupported`` error.
+    /// - throws: If a specific `HKSample` type is not supported, or if the sample for some reason cannot be turned as a FHIR resource
+    ///     (e.g., because it contains values that cannot be represented using the FHIR types)
     ///
     /// - Important: When mapping an array of HKSample objects into ResourceProxies, for performance reasons always prefer ``Swift/Sequence/mapIntoResourceProxies(using:extensions:)`` or ``Swift/Sequence/mapIntoResourceProxies(using:extensions:)``.
     public func resource(

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKSample+ResourceProxy.swift
@@ -19,7 +19,7 @@ extension HKSample {
     /// - parameter extensions: Any ``FHIRExtensionBuilder``s that should be applied to each of the produced observations.
     ///     The ``FHIRExtensionBuilder/sourceDevice-9m1t7``, ``FHIRExtensionBuilder/sourceRevision-8b3xb``, and ``FHIRExtensionBuilder/metadata`` extension builders are always enabled when creating a FHIR `Observation`s from a `HKSample`.
     /// - returns: A `ResourceProxy`containing an FHIR  `Observation` based on the concrete subclass of `HKSample`.
-    /// - throws: If a specific `HKSample` type is not supported, or if the sample for some reason cannot be turned as a FHIR resource
+    /// - throws: If a specific `HKSample` type is not supported, or if the sample for some reason cannot be turned into a FHIR resource
     ///     (e.g., because it contains values that cannot be represented using the FHIR types)
     ///
     /// - Important: When mapping an array of HKSample objects into ResourceProxies, for performance reasons always prefer ``Swift/Sequence/mapIntoResourceProxies(using:extensions:)`` or ``Swift/Sequence/mapIntoResourceProxies(using:extensions:)``.
@@ -87,9 +87,9 @@ extension Sequence where Element: HKSample {
     
     /// Produces an Array of FHIR `ResourceProxies`.
     ///
-    /// This function is equivalent to calling ``HealthKit/HKSample/resource(withMapping:issuedDate:extensions:)`` on every element in the sequence, and filtering out those elememt for which the call raised an error.
+    /// This function is equivalent to calling ``HealthKit/HKSample/resource(withMapping:issuedDate:extensions:)`` on every element in the sequence, and filtering out those elements for which the call raised an error.
     ///
-    /// - Note: This method provides significant performance improvements as compared to calling ``HealthKit/HKSample/resource(withMapping:issuedDate:extensions:)`` for each element in the collection.
+    /// - Note: This method provides significant performance improvements as compared to calling ``HealthKit/HKSample/resource(withMapping:issuedDate:extensions:)`` on each element in the collection.
     ///
     /// - parameter mapping: A mapping to map `HKSample`s to corresponding FHIR observations allowing the customization of, e.g., codings and units. See ``HKSampleMapping``.
     /// - parameter issuedDate: `Instant` specifying when this version of the resource was made available. Defaults to `Date.now`.

--- a/Sources/HealthKitOnFHIR/HealthKit Extensions/HKStateOfMind+Observation.swift
+++ b/Sources/HealthKitOnFHIR/HealthKit Extensions/HKStateOfMind+Observation.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import FHIRModelsExtensions
 import HealthKit
 import ModelsR4
 
@@ -26,7 +27,7 @@ extension HKStateOfMind: FHIRObservationBuildable {
         ))
         observation.appendComponent(.init(
             code: CodeableConcept(coding: mapping.valence.codings.map(\.coding)),
-            value: .quantity(.init(value: self.valence.asFHIRDecimalPrimitive()))
+            value: .quantity(.init(value: try self.valence.asFHIRDecimalPrimitiveSafe()))
         ))
         observation.appendComponent(.init(
             code: CodeableConcept(coding: mapping.valenceClassification.codings.map(\.coding)),

--- a/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
+++ b/Tests/HealthKitOnFHIRTests/HKQuantitySampleTests.swift
@@ -2173,6 +2173,53 @@ struct HKQuantitySampleTests {
         #expect(sample.quantityType.codes.isEmpty)
     }
     
+    @Test func invalidValue() throws {
+        #expect(Decimal(Double.nan).doubleValue.isNaN)
+        #expect(Decimal(Double.signalingNaN).doubleValue.isNaN)
+        
+        let unit: HKUnit = .count().unitDivided(by: .minute())
+        let makeSample = {
+            HKQuantitySample(
+                type: HKQuantityType(.heartRate),
+                quantity: HKQuantity(unit: unit, doubleValue: $0),
+                start: .now,
+                end: .now
+            )
+        }
+        #expect(throws: (any Error).self) {
+            try makeSample(+.infinity).resource()
+        }
+        #expect(throws: (any Error).self) {
+            try makeSample(-.infinity).resource()
+        }
+        #expect(throws: Never.self) {
+            try makeSample(.nan).resource()
+        }
+        
+        let samples = [
+            makeSample(+.infinity),
+            makeSample(-.infinity),
+            makeSample(.nan),
+            makeSample(.signalingNaN),
+            makeSample(+0),
+            makeSample(-0)
+        ]
+        
+        let resources = try samples.compactMapIntoResourceProxies()
+        let values: [Double] = resources.compactMap { resource in
+            guard let observation = resource.get(if: Observation.self) else {
+                return nil
+            }
+            switch observation.value {
+            case .quantity(let quantity):
+                return quantity.value?.value?.decimal.doubleValue
+            default:
+                return nil
+            }
+        }
+        #expect(values.map(\.bitPattern) == [Double.nan, .nan, 0, 0].map(\.bitPattern))
+    }
+    
     @Test
     func collectionSampleToResourceProxy() throws {
         func makeSample(numSteps: Int, date: DateComponents) throws -> HKQuantitySample {


### PR DESCRIPTION
# fix crash when encountering infinity values#2

## :recycle: Current situation & Problem
see #67


## :gear: Release Notes
- attempting to create a FHIR resource containing invalid `Double.infinity` values will now throw an error, instead of unconditionally crashing the app


## :books: Documentation
yes (a little)


## :white_check_mark: Testing
yes (a lot)


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer handling and validation of numeric values (infinity, NaN, signed zeros) and quantity/decimal conversions; conversion errors now propagate where appropriate to avoid invalid FHIR output.

* **Tests**
  * Added tests for invalid numeric inputs to verify throwing behavior and preserved value semantics.

* **Refactor**
  * Consolidated lint/plugin integration and updated package metadata for build-time configuration.

* **Documentation**
  * Minor docstring clarifications and typo fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->