### PR TITLE
limit FHIRModels dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,9 +29,9 @@ let package = Package(
         .library(name: "HealthKitOnFHIR", targets: ["HealthKitOnFHIR"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
-        .package(url: "https://github.com/StanfordBDHG/FHIRModelsExtensions.git", from: "0.1.1"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
+        .package(url: "https://github.com/apple/FHIRModels.git", "0.8.0"..<"0.9.0"),
+        .package(url: "https://github.com/StanfordBDHG/FHIRModelsExtensions.git", from: "0.1.2"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "602.0.0"..<"605.0.0"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.0")
     ] + swiftLintPackage,


### PR DESCRIPTION
# limit FHIRModels dependency

## :recycle: Current situation & Problem
FHIRModels tagged a breaking 0.9.0 release, which our codebase will need to be updated to support.
in the meantime, we tighten our version requirement to keep our code compiling until we can update all our packages to the new types.


## :gear: Release Notes
- FHIRModels dependency now is explicitly limited to `0.8.0..<0.9.0`


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
